### PR TITLE
 Fix for incorrect null handling in arrays of unions

### DIFF
--- a/src/main/java/com/rtbhouse/utils/avro/FastDeserializerGenerator.java
+++ b/src/main/java/com/rtbhouse/utils/avro/FastDeserializerGenerator.java
@@ -438,7 +438,11 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
             FieldAction unionAction;
 
             if (Schema.Type.NULL.equals(optionSchema.getType())) {
-                body._if(unionIndex.eq(JExpr.lit(i)))._then().directStatement(DECODER + ".readNull();");
+                JBlock nullReadBlock = body._if(unionIndex.eq(JExpr.lit(i)))._then().block();
+                nullReadBlock.directStatement(DECODER + ".readNull();");
+                if (action.getShouldRead()) {
+                    putValueIntoParent.accept(nullReadBlock, JExpr._null());
+                }
                 continue;
             }
 

--- a/src/test/java/com/rtbhouse/utils/avro/FastDatumReaderTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastDatumReaderTest.java
@@ -2,7 +2,9 @@ package com.rtbhouse.utils.avro;
 
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createPrimitiveUnionFieldSchema;
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createRecord;
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.specificDataAsDecoder;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.emptyTestRecord;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeGeneric;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeSpecific;
 
 import java.io.IOException;
 
@@ -33,11 +35,11 @@ public class FastDatumReaderTest {
         FastSpecificDatumReader<TestRecord> fastSpecificDatumReader = new FastSpecificDatumReader<>(
                 TestRecord.getClassSchema(), cache);
 
-        TestRecord testRecord = FastSpecificDeserializerGeneratorTest.emptyTestRecord();
+        TestRecord testRecord = emptyTestRecord();
         testRecord.put("testEnum", TestEnum.A);
 
         // when
-        fastSpecificDatumReader.read(null, specificDataAsDecoder(testRecord));
+        fastSpecificDatumReader.read(null, serializeSpecific(testRecord));
 
         // then
         FastDeserializer<TestRecord> fastSpecificDeserializer =
@@ -53,7 +55,7 @@ public class FastDatumReaderTest {
         Assert.assertEquals(
                 TestEnum.A,
                 fastSpecificDatumReader.read(null,
-                        FastSerdeTestsSupport.specificDataAsDecoder(testRecord)).getTestEnum());
+                        FastSerdeTestsSupport.serializeSpecific(testRecord)).getTestEnum());
     }
 
     @Test
@@ -64,11 +66,11 @@ public class FastDatumReaderTest {
         FastSpecificDatumReader<TestRecord> fastSpecificDatumReader = new FastSpecificDatumReader<>(
                 TestRecord.getClassSchema(), faultySchema, cache);
 
-        TestRecord testRecord = FastSpecificDeserializerGeneratorTest.emptyTestRecord();
+        TestRecord testRecord = emptyTestRecord();
         testRecord.put("testEnum", TestEnum.A);
 
         // when
-        fastSpecificDatumReader.read(null, FastSerdeTestsSupport.specificDataAsDecoder(testRecord));
+        fastSpecificDatumReader.read(null, FastSerdeTestsSupport.serializeSpecific(testRecord));
 
         // then
         FastDeserializer<TestRecord> fastSpecificDeserializer =
@@ -95,7 +97,7 @@ public class FastDatumReaderTest {
         recordBuilder.set("test", "test");
 
         // when
-        fastGenericDatumReader.read(null, FastSerdeTestsSupport.genericDataAsDecoder(recordBuilder.build()));
+        fastGenericDatumReader.read(null, serializeGeneric(recordBuilder.build()));
 
         // then
         FastDeserializer<GenericRecord> fastGenericDeserializer =
@@ -110,6 +112,6 @@ public class FastDatumReaderTest {
         Assert.assertNotEquals(2, fastGenericDeserializer.getClass().getDeclaredMethods().length);
         Assert.assertEquals(
                 "test",
-                fastGenericDatumReader.read(null, FastSerdeTestsSupport.genericDataAsDecoder(recordBuilder.build())).get("test"));
+                fastGenericDatumReader.read(null, serializeGeneric(recordBuilder.build())).get("test"));
     }
 }

--- a/src/test/java/com/rtbhouse/utils/avro/FastDatumWriterTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastDatumWriterTest.java
@@ -2,6 +2,7 @@ package com.rtbhouse.utils.avro;
 
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createPrimitiveUnionFieldSchema;
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createRecord;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.emptyTestRecord;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -33,7 +34,7 @@ public class FastDatumWriterTest {
         FastSpecificDatumWriter<TestRecord> fastSpecificDatumWriter = new FastSpecificDatumWriter<>(
                 TestRecord.getClassSchema(), cache);
 
-        TestRecord testRecord = FastSpecificDeserializerGeneratorTest.emptyTestRecord();
+        TestRecord testRecord = emptyTestRecord();
         testRecord.put("testEnum", TestEnum.A);
 
         // when

--- a/src/test/java/com/rtbhouse/utils/avro/FastDeserializerDefaultsTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastDeserializerDefaultsTest.java
@@ -1,6 +1,6 @@
 package com.rtbhouse.utils.avro;
 
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.genericDataAsDecoder;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeGeneric;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,8 +63,8 @@ public class FastDeserializerDefaultsTest {
         oldRecord.put("oldSubRecord", oldSubRecord);
 
         // when
-        DefaultsTestRecord testRecord = decodeSpecificFast(DefaultsTestRecord.getClassSchema(), oldRecordSchema,
-                genericDataAsDecoder(oldRecord));
+        DefaultsTestRecord testRecord = deserializeSpecificFast(DefaultsTestRecord.getClassSchema(), oldRecordSchema,
+                serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals(oldSubRecord.get("oldSubField"),
@@ -139,8 +139,8 @@ public class FastDeserializerDefaultsTest {
         oldRecord.put("oldSubRecord", oldSubRecord);
 
         // when
-        GenericRecord testRecord = decodeGenericFast(DefaultsTestRecord.getClassSchema(), oldRecordSchema,
-                genericDataAsDecoder(oldRecord));
+        GenericRecord testRecord = deserializeGenericFast(DefaultsTestRecord.getClassSchema(), oldRecordSchema,
+                serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals(oldSubRecord.get("oldSubField"),
@@ -218,10 +218,10 @@ public class FastDeserializerDefaultsTest {
         oldRecord.put("oldSubRecord", oldSubRecord);
 
         // when
-        DefaultsTestRecord testRecordSlow = decodeSpecificSlow(DefaultsTestRecord.getClassSchema(),
-                oldRecordSchema, genericDataAsDecoder(oldRecord));
-        DefaultsTestRecord testRecordFast = decodeSpecificFast(DefaultsTestRecord.getClassSchema(),
-                oldRecordSchema, genericDataAsDecoder(oldRecord));
+        DefaultsTestRecord testRecordSlow = deserializeSpecificSlow(DefaultsTestRecord.getClassSchema(),
+                oldRecordSchema, serializeGeneric(oldRecord));
+        DefaultsTestRecord testRecordFast = deserializeSpecificFast(DefaultsTestRecord.getClassSchema(),
+                oldRecordSchema, serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals(testRecordSlow, testRecordFast);
@@ -239,10 +239,10 @@ public class FastDeserializerDefaultsTest {
         oldRecord.put("oldSubRecord", oldSubRecord);
 
         // when
-        GenericRecord testRecordSlow = decodeGenericSlow(DefaultsTestRecord.getClassSchema(),
-                oldRecordSchema, genericDataAsDecoder(oldRecord));
-        GenericRecord testRecordFast = decodeGenericFast(DefaultsTestRecord.getClassSchema(),
-                oldRecordSchema, genericDataAsDecoder(oldRecord));
+        GenericRecord testRecordSlow = deserializeGenericSlow(DefaultsTestRecord.getClassSchema(),
+                oldRecordSchema, serializeGeneric(oldRecord));
+        GenericRecord testRecordFast = deserializeGenericFast(DefaultsTestRecord.getClassSchema(),
+                oldRecordSchema, serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals(testRecordSlow, testRecordFast);
@@ -292,7 +292,7 @@ public class FastDeserializerDefaultsTest {
         Schema newRecordSchema = parser
                 .parse(this.getClass().getResourceAsStream("/schema/defaultsTestSubrecord.avsc"));
         // when
-        GenericRecord record = decodeGenericFast(newRecordSchema, oldRecordSchema, genericDataAsDecoder(oldRecord));
+        GenericRecord record = deserializeGenericFast(newRecordSchema, oldRecordSchema, serializeGeneric(oldRecord));
 
         // then
         GenericData.Record newSubRecord = new GenericData.Record(newRecordSchema.getField("subRecordUnion")
@@ -337,7 +337,7 @@ public class FastDeserializerDefaultsTest {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T decodeSpecificSlow(Schema readerSchema, Schema writerSchema, Decoder decoder) {
+    private <T> T deserializeSpecificSlow(Schema readerSchema, Schema writerSchema, Decoder decoder) {
         org.apache.avro.io.DatumReader<T> datumReader = new SpecificDatumReader<>(writerSchema, readerSchema);
         try {
             return datumReader.read(null, decoder);
@@ -349,7 +349,7 @@ public class FastDeserializerDefaultsTest {
     }
 
     @SuppressWarnings("unchecked")
-    private GenericRecord decodeGenericSlow(Schema readerSchema, Schema writerSchema, Decoder decoder) {
+    private GenericRecord deserializeGenericSlow(Schema readerSchema, Schema writerSchema, Decoder decoder) {
         org.apache.avro.io.DatumReader<GenericData> datumReader = new GenericDatumReader<>(writerSchema, readerSchema);
         try {
             return (GenericRecord) datumReader.read(null, decoder);
@@ -361,7 +361,7 @@ public class FastDeserializerDefaultsTest {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T decodeSpecificFast(Schema readerSchema, Schema writerSchema, Decoder decoder) {
+    private <T> T deserializeSpecificFast(Schema readerSchema, Schema writerSchema, Decoder decoder) {
         FastDeserializer<T> deserializer = new FastSpecificDeserializerGenerator(writerSchema,
                 readerSchema, tempDir, classLoader, null).generateDeserializer();
 
@@ -373,7 +373,7 @@ public class FastDeserializerDefaultsTest {
     }
 
     @SuppressWarnings("unchecked")
-    private GenericRecord decodeGenericFast(Schema readerSchema, Schema writerSchema, Decoder decoder) {
+    private GenericRecord deserializeGenericFast(Schema readerSchema, Schema writerSchema, Decoder decoder) {
         FastDeserializer<GenericRecord> deserializer = new FastGenericDeserializerGenerator(writerSchema,
                 readerSchema, tempDir, classLoader, null).generateDeserializer();
 

--- a/src/test/java/com/rtbhouse/utils/avro/FastGenericDeserializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastGenericDeserializerGeneratorTest.java
@@ -11,7 +11,7 @@ import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createPrimitiveUnion
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createRecord;
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createUnionField;
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createUnionSchema;
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.genericDataAsDecoder;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeGeneric;
 
 import java.io.File;
 import java.net.URL;
@@ -44,28 +44,28 @@ public class FastGenericDeserializerGeneratorTest {
         Path tempPath = Files.createTempDirectory("generated");
         tempDir = tempPath.toFile();
 
-        classLoader = URLClassLoader.newInstance(new URL[]{ tempDir.toURI().toURL() },
-            FastGenericDeserializerGeneratorTest.class.getClassLoader());
+        classLoader = URLClassLoader.newInstance(new URL[] { tempDir.toURI().toURL() },
+                FastGenericDeserializerGeneratorTest.class.getClassLoader());
     }
 
     @Test
     public void shouldReadPrimitives() {
         // given
         Schema recordSchema = createRecord("testRecord",
-            createField("testInt", Schema.create(Schema.Type.INT)),
-            createPrimitiveUnionFieldSchema("testIntUnion", Schema.Type.INT),
-            createField("testString", Schema.create(Schema.Type.STRING)),
-            createPrimitiveUnionFieldSchema("testStringUnion", Schema.Type.STRING),
-            createField("testLong", Schema.create(Schema.Type.LONG)),
-            createPrimitiveUnionFieldSchema("testLongUnion", Schema.Type.LONG),
-            createField("testDouble", Schema.create(Schema.Type.DOUBLE)),
-            createPrimitiveUnionFieldSchema("testDoubleUnion", Schema.Type.DOUBLE),
-            createField("testFloat", Schema.create(Schema.Type.FLOAT)),
-            createPrimitiveUnionFieldSchema("testFloatUnion", Schema.Type.FLOAT),
-            createField("testBoolean", Schema.create(Schema.Type.BOOLEAN)),
-            createPrimitiveUnionFieldSchema("testBooleanUnion", Schema.Type.BOOLEAN),
-            createField("testBytes", Schema.create(Schema.Type.BYTES)),
-            createPrimitiveUnionFieldSchema("testBytesUnion", Schema.Type.BYTES));
+                createField("testInt", Schema.create(Schema.Type.INT)),
+                createPrimitiveUnionFieldSchema("testIntUnion", Schema.Type.INT),
+                createField("testString", Schema.create(Schema.Type.STRING)),
+                createPrimitiveUnionFieldSchema("testStringUnion", Schema.Type.STRING),
+                createField("testLong", Schema.create(Schema.Type.LONG)),
+                createPrimitiveUnionFieldSchema("testLongUnion", Schema.Type.LONG),
+                createField("testDouble", Schema.create(Schema.Type.DOUBLE)),
+                createPrimitiveUnionFieldSchema("testDoubleUnion", Schema.Type.DOUBLE),
+                createField("testFloat", Schema.create(Schema.Type.FLOAT)),
+                createPrimitiveUnionFieldSchema("testFloatUnion", Schema.Type.FLOAT),
+                createField("testBoolean", Schema.create(Schema.Type.BOOLEAN)),
+                createPrimitiveUnionFieldSchema("testBooleanUnion", Schema.Type.BOOLEAN),
+                createField("testBytes", Schema.create(Schema.Type.BYTES)),
+                createPrimitiveUnionFieldSchema("testBytesUnion", Schema.Type.BYTES));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(recordSchema);
         builder.set("testInt", 1);
@@ -80,11 +80,11 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("testFloatUnion", 1.0f);
         builder.set("testBoolean", true);
         builder.set("testBooleanUnion", true);
-        builder.set("testBytes", ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }));
-        builder.set("testBytesUnion", ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }));
+        builder.set("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
+        builder.set("testBytesUnion", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals(1, record.get("testInt"));
@@ -99,8 +99,8 @@ public class FastGenericDeserializerGeneratorTest {
         Assert.assertEquals(1.0f, record.get("testFloatUnion"));
         Assert.assertEquals(true, record.get("testBoolean"));
         Assert.assertEquals(true, record.get("testBooleanUnion"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }), record.get("testBytes"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }), record.get("testBytesUnion"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytes"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytesUnion"));
 
     }
 
@@ -109,32 +109,35 @@ public class FastGenericDeserializerGeneratorTest {
         // given
         Schema fixedSchema = createFixedSchema("testFixed", 2);
         Schema recordSchema = createRecord("testRecord", createField("testFixed", fixedSchema),
-            createUnionField("testFixedUnion", fixedSchema), createArrayFieldSchema("testFixedArray", fixedSchema),
-            createArrayFieldSchema("testFixedUnionArray", createUnionSchema(fixedSchema)));
+                createUnionField("testFixedUnion", fixedSchema), createArrayFieldSchema("testFixedArray", fixedSchema),
+                createArrayFieldSchema("testFixedUnionArray", createUnionSchema(fixedSchema)));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(recordSchema);
-        builder.set("testFixed", new GenericData.Fixed(fixedSchema, new byte[]{ 0x01, 0x02 }));
-        builder.set("testFixedUnion", new GenericData.Fixed(fixedSchema, new byte[]{ 0x03, 0x04 }));
-        builder.set("testFixedArray", Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[]{ 0x05, 0x06 })));
-        builder.set("testFixedUnionArray", Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[]{ 0x07, 0x08 })));
+        builder.set("testFixed", new GenericData.Fixed(fixedSchema, new byte[] { 0x01, 0x02 }));
+        builder.set("testFixedUnion", new GenericData.Fixed(fixedSchema, new byte[] { 0x03, 0x04 }));
+        builder.set("testFixedArray", Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[] { 0x05, 0x06 })));
+        builder.set("testFixedUnionArray",
+                Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[] { 0x07, 0x08 })));
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
-        Assert.assertArrayEquals(new byte[]{ 0x01, 0x02 }, ((GenericData.Fixed) record.get("testFixed")).bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x03, 0x04 }, ((GenericData.Fixed) record.get("testFixedUnion")).bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x05, 0x06 }, ((List<GenericData.Fixed>) record.get("testFixedArray")).get(0).bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x07, 0x08 }, ((List<GenericData.Fixed>) record.get("testFixedUnionArray")).get(0).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x01, 0x02 }, ((GenericData.Fixed) record.get("testFixed")).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x03, 0x04 }, ((GenericData.Fixed) record.get("testFixedUnion")).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x05, 0x06 },
+                ((List<GenericData.Fixed>) record.get("testFixedArray")).get(0).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x07, 0x08 },
+                ((List<GenericData.Fixed>) record.get("testFixedUnionArray")).get(0).bytes());
     }
 
     @Test
     public void shouldReadEnum() {
         // given
-        Schema enumSchema = createEnumSchema("testEnum", new String[]{ "A", "B" });
+        Schema enumSchema = createEnumSchema("testEnum", new String[] { "A", "B" });
         Schema recordSchema = createRecord("testRecord", createField("testEnum", enumSchema),
-            createUnionField("testEnumUnion", enumSchema), createArrayFieldSchema("testEnumArray", enumSchema),
-            createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema)));
+                createUnionField("testEnumUnion", enumSchema), createArrayFieldSchema("testEnumArray", enumSchema),
+                createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema)));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(recordSchema);
         builder.set("testEnum", new GenericData.EnumSymbol(enumSchema, "A"));
@@ -143,7 +146,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("testEnumUnionArray", Arrays.asList(new GenericData.EnumSymbol(enumSchema, "A")));
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("A", record.get("testEnum").toString());
@@ -155,10 +158,10 @@ public class FastGenericDeserializerGeneratorTest {
     @Test
     public void shouldReadPermutatedEnum() {
         // given
-        Schema enumSchema = createEnumSchema("testEnum", new String[]{ "A", "B", "C", "D", "E" });
+        Schema enumSchema = createEnumSchema("testEnum", new String[] { "A", "B", "C", "D", "E" });
         Schema recordSchema = createRecord("testRecord", createField("testEnum", enumSchema),
-            createUnionField("testEnumUnion", enumSchema), createArrayFieldSchema("testEnumArray", enumSchema),
-            createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema)));
+                createUnionField("testEnumUnion", enumSchema), createArrayFieldSchema("testEnumArray", enumSchema),
+                createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema)));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(recordSchema);
         builder.set("testEnum", new GenericData.EnumSymbol(enumSchema, "A"));
@@ -166,13 +169,13 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("testEnumArray", Arrays.asList(new GenericData.EnumSymbol(enumSchema, "C")));
         builder.set("testEnumUnionArray", Arrays.asList(new GenericData.EnumSymbol(enumSchema, "D")));
 
-        Schema enumSchema1 = createEnumSchema("testEnum", new String[]{ "B", "A", "D", "E", "C" });
+        Schema enumSchema1 = createEnumSchema("testEnum", new String[] { "B", "A", "D", "E", "C" });
         Schema recordSchema1 = createRecord("testRecord", createField("testEnum", enumSchema1),
-            createUnionField("testEnumUnion", enumSchema1), createArrayFieldSchema("testEnumArray", enumSchema1),
-            createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema1)));
+                createUnionField("testEnumUnion", enumSchema1), createArrayFieldSchema("testEnumArray", enumSchema1),
+                createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema1)));
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema1, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema1, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("A", record.get("testEnum").toString());
@@ -184,27 +187,27 @@ public class FastGenericDeserializerGeneratorTest {
     @Test(expected = FastDeserializerGeneratorException.class)
     public void shouldNotReadStrippedEnum() {
         // given
-        Schema enumSchema = createEnumSchema("testEnum", new String[]{ "A", "B", "C" });
+        Schema enumSchema = createEnumSchema("testEnum", new String[] { "A", "B", "C" });
         Schema recordSchema = createRecord("testRecord", createField("testEnum", enumSchema));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(recordSchema);
         builder.set("testEnum", new GenericData.EnumSymbol(enumSchema, "C"));
 
-        Schema enumSchema1 = createEnumSchema("testEnum", new String[]{ "A", "B" });
+        Schema enumSchema1 = createEnumSchema("testEnum", new String[] { "A", "B" });
         Schema recordSchema1 = createRecord("testRecord", createField("testEnum", enumSchema1));
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema1, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema1, serializeGeneric(builder.build()));
     }
 
     @Test
     public void shouldReadSubRecordField() {
         // given
         Schema subRecordSchema = createRecord("subRecord",
-            createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
 
         Schema recordSchema = createRecord("test", createUnionField("record", subRecordSchema),
-            createField("record1", subRecordSchema), createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));
+                createField("record1", subRecordSchema), createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecordSchema);
         subRecordBuilder.set("subField", "abc");
@@ -215,7 +218,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("field", "abc");
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", ((GenericRecord) record.get("record")).get("subField"));
@@ -229,11 +232,11 @@ public class FastGenericDeserializerGeneratorTest {
     public void shouldReadSubRecordCollectionsField() {
         // given
         Schema subRecordSchema = createRecord("subRecord",
-            createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
         Schema recordSchema = createRecord("test", createArrayFieldSchema("recordsArray", subRecordSchema),
-            createMapFieldSchema("recordsMap", subRecordSchema),
-            createUnionField("recordsArrayUnion", Schema.createArray(createUnionSchema(subRecordSchema))),
-            createUnionField("recordsMapUnion", Schema.createMap(createUnionSchema(subRecordSchema))));
+                createMapFieldSchema("recordsMap", subRecordSchema),
+                createUnionField("recordsArrayUnion", Schema.createArray(createUnionSchema(subRecordSchema))),
+                createUnionField("recordsMapUnion", Schema.createMap(createUnionSchema(subRecordSchema))));
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecordSchema);
         subRecordBuilder.set("subField", "abc");
@@ -249,32 +252,32 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("recordsMapUnion", recordsMap);
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc",
-            ((List<GenericData.Record>) record.get("recordsArray")).get(0).get("subField"));
+                ((List<GenericData.Record>) record.get("recordsArray")).get(0).get("subField"));
         Assert.assertEquals("abc",
-            ((List<GenericData.Record>) record.get("recordsArrayUnion")).get(0).get("subField"));
+                ((List<GenericData.Record>) record.get("recordsArrayUnion")).get(0).get("subField"));
         Assert.assertEquals("abc",
-            ((Map<String, GenericData.Record>) record.get("recordsMap")).get("1").get("subField"));
+                ((Map<String, GenericData.Record>) record.get("recordsMap")).get("1").get("subField"));
         Assert.assertEquals("abc",
-            ((Map<String, GenericData.Record>) record.get("recordsMapUnion")).get("1").get("subField"));
+                ((Map<String, GenericData.Record>) record.get("recordsMapUnion")).get("1").get("subField"));
     }
 
     @Test
     public void shouldReadSubRecordComplexCollectionsField() {
         // given
         Schema subRecordSchema = createRecord("subRecord",
-            createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
         Schema recordSchema = createRecord(
-            "test",
-            createArrayFieldSchema("recordsArrayMap", Schema.createMap(createUnionSchema(subRecordSchema))),
-            createMapFieldSchema("recordsMapArray", Schema.createArray(createUnionSchema(subRecordSchema))),
-            createUnionField("recordsArrayMapUnion",
-                Schema.createArray(Schema.createMap(createUnionSchema(subRecordSchema)))),
-            createUnionField("recordsMapArrayUnion",
-                Schema.createMap(Schema.createArray(createUnionSchema(subRecordSchema)))));
+                "test",
+                createArrayFieldSchema("recordsArrayMap", Schema.createMap(createUnionSchema(subRecordSchema))),
+                createMapFieldSchema("recordsMapArray", Schema.createArray(createUnionSchema(subRecordSchema))),
+                createUnionField("recordsArrayMapUnion",
+                        Schema.createArray(Schema.createMap(createUnionSchema(subRecordSchema)))),
+                createUnionField("recordsMapArrayUnion",
+                        Schema.createMap(Schema.createArray(createUnionSchema(subRecordSchema)))));
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecordSchema);
         subRecordBuilder.set("subField", "abc");
@@ -297,36 +300,38 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("recordsMapArrayUnion", recordsMapArray);
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc",
-            ((List<Map<String, GenericRecord>>) record.get("recordsArrayMap")).get(0).get("1").get("subField"));
+                ((List<Map<String, GenericRecord>>) record.get("recordsArrayMap")).get(0).get("1").get("subField"));
         Assert.assertEquals("abc",
-            ((Map<String, List<GenericRecord>>) record.get("recordsMapArray")).get("1").get(0).get("subField"));
+                ((Map<String, List<GenericRecord>>) record.get("recordsMapArray")).get("1").get(0).get("subField"));
         Assert.assertEquals("abc",
-            ((List<Map<String, GenericRecord>>) record.get("recordsArrayMapUnion")).get(0).get("1").get("subField"));
+                ((List<Map<String, GenericRecord>>) record.get("recordsArrayMapUnion")).get(0).get("1")
+                        .get("subField"));
         Assert.assertEquals("abc",
-            ((Map<String, List<GenericRecord>>) record.get("recordsMapArrayUnion")).get("1").get(0).get("subField"));
+                ((Map<String, List<GenericRecord>>) record.get("recordsMapArrayUnion")).get("1").get(0)
+                        .get("subField"));
     }
 
     @Test
     public void shouldReadAliasedField() {
         // given
         Schema record1Schema = createRecord("test", createPrimitiveUnionFieldSchema("testString", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testStringUnion", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("testStringUnion", Schema.Type.STRING));
         Schema record2Schema = createRecord(
-            "test",
-            createPrimitiveUnionFieldSchema("testString", Schema.Type.STRING),
-            addAliases(createPrimitiveUnionFieldSchema("testStringUnionAlias", Schema.Type.STRING),
-                "testStringUnion"));
+                "test",
+                createPrimitiveUnionFieldSchema("testString", Schema.Type.STRING),
+                addAliases(createPrimitiveUnionFieldSchema("testStringUnionAlias", Schema.Type.STRING),
+                        "testStringUnion"));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(record1Schema);
         builder.set("testString", "abc");
         builder.set("testStringUnion", "def");
 
         // when
-        GenericRecord record = decodeRecord(record1Schema, record2Schema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(record1Schema, record2Schema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", record.get("testString"));
@@ -337,25 +342,25 @@ public class FastGenericDeserializerGeneratorTest {
     public void shouldSkipRemovedField() {
         // given
         Schema subRecord1Schema = createRecord("subRecord",
-            createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testRemoved", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
+                createPrimitiveUnionFieldSchema("testRemoved", Schema.Type.STRING),
+                createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING));
         Schema record1Schema = createRecord("test",
-            createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testRemoved", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING),
-            createUnionField("subRecord", subRecord1Schema),
-            createMapFieldSchema("subRecordMap", subRecord1Schema),
-            createArrayFieldSchema("subRecordArray", subRecord1Schema));
+                createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
+                createPrimitiveUnionFieldSchema("testRemoved", Schema.Type.STRING),
+                createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING),
+                createUnionField("subRecord", subRecord1Schema),
+                createMapFieldSchema("subRecordMap", subRecord1Schema),
+                createArrayFieldSchema("subRecordArray", subRecord1Schema));
         Schema subRecord2Schema = createRecord("subRecord",
-            createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
+                createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING));
         Schema record2Schema = createRecord("test",
-            createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
-            createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING),
-            createUnionField("subRecord", subRecord2Schema),
-            createMapFieldSchema("subRecordMap", subRecord2Schema),
-            createArrayFieldSchema("subRecordArray", subRecord2Schema));
+                createPrimitiveUnionFieldSchema("testNotRemoved", Schema.Type.STRING),
+                createPrimitiveUnionFieldSchema("testNotRemoved2", Schema.Type.STRING),
+                createUnionField("subRecord", subRecord2Schema),
+                createMapFieldSchema("subRecordMap", subRecord2Schema),
+                createArrayFieldSchema("subRecordArray", subRecord2Schema));
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecord1Schema);
         subRecordBuilder.set("testNotRemoved", "abc");
@@ -374,7 +379,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("subRecordMap", recordsMap);
 
         // when
-        GenericRecord record = decodeRecord(record1Schema, record2Schema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(record1Schema, record2Schema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", record.get("testNotRemoved"));
@@ -383,28 +388,28 @@ public class FastGenericDeserializerGeneratorTest {
         Assert.assertEquals("ghi", ((GenericRecord) record.get("subRecord")).get("testNotRemoved2"));
         Assert.assertEquals("ghi", ((List<GenericRecord>) record.get("subRecordArray")).get(0).get("testNotRemoved2"));
         Assert.assertEquals("ghi",
-            ((Map<String, GenericRecord>) record.get("subRecordMap")).get("1").get("testNotRemoved2"));
+                ((Map<String, GenericRecord>) record.get("subRecordMap")).get("1").get("testNotRemoved2"));
     }
 
     @Test
     public void shouldSkipRemovedRecord() {
         // given
         Schema subRecord1Schema = createRecord("subRecord",
-            createPrimitiveFieldSchema("test1", Schema.Type.STRING),
-            createPrimitiveFieldSchema("test2", Schema.Type.STRING));
+                createPrimitiveFieldSchema("test1", Schema.Type.STRING),
+                createPrimitiveFieldSchema("test2", Schema.Type.STRING));
         Schema subRecord2Schema = createRecord("subRecord2",
-            createPrimitiveFieldSchema("test1", Schema.Type.STRING),
-            createPrimitiveFieldSchema("test2", Schema.Type.STRING));
+                createPrimitiveFieldSchema("test1", Schema.Type.STRING),
+                createPrimitiveFieldSchema("test2", Schema.Type.STRING));
 
         Schema record1Schema = createRecord("test",
-            createField("subRecord1", subRecord1Schema),
-            createField("subRecord2", subRecord2Schema),
-            createUnionField("subRecord3", subRecord2Schema),
-            createField("subRecord4", subRecord1Schema));
+                createField("subRecord1", subRecord1Schema),
+                createField("subRecord2", subRecord2Schema),
+                createUnionField("subRecord3", subRecord2Schema),
+                createField("subRecord4", subRecord1Schema));
 
         Schema record2Schema = createRecord("test",
-            createField("subRecord1", subRecord1Schema),
-            createField("subRecord4", subRecord1Schema));
+                createField("subRecord1", subRecord1Schema),
+                createField("subRecord4", subRecord1Schema));
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecord1Schema);
         subRecordBuilder.set("test1", "abc");
@@ -421,7 +426,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("subRecord4", subRecordBuilder.build());
 
         // when
-        GenericRecord record = decodeRecord(record1Schema, record2Schema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(record1Schema, record2Schema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", ((GenericRecord) record.get("subRecord1")).get("test1"));
@@ -434,28 +439,26 @@ public class FastGenericDeserializerGeneratorTest {
     public void shouldSkipRemovedNestedRecord() {
         // given
         Schema subSubRecordSchema = createRecord("subSubRecord",
-            createPrimitiveFieldSchema("test1", Schema.Type.STRING),
-            createPrimitiveFieldSchema("test2", Schema.Type.STRING));
+                createPrimitiveFieldSchema("test1", Schema.Type.STRING),
+                createPrimitiveFieldSchema("test2", Schema.Type.STRING));
         Schema subRecord1Schema = createRecord("subRecord",
-            createPrimitiveFieldSchema("test1", Schema.Type.STRING),
-            createField("test2", subSubRecordSchema),
-            createUnionField("test3", subSubRecordSchema),
-            createPrimitiveFieldSchema("test4", Schema.Type.STRING));
+                createPrimitiveFieldSchema("test1", Schema.Type.STRING),
+                createField("test2", subSubRecordSchema),
+                createUnionField("test3", subSubRecordSchema),
+                createPrimitiveFieldSchema("test4", Schema.Type.STRING));
         Schema subRecord2Schema = createRecord("subRecord",
-            createPrimitiveFieldSchema("test1", Schema.Type.STRING),
-            createPrimitiveFieldSchema("test4", Schema.Type.STRING));
-
+                createPrimitiveFieldSchema("test1", Schema.Type.STRING),
+                createPrimitiveFieldSchema("test4", Schema.Type.STRING));
 
         Schema record1Schema = createRecord("test",
-            createField("subRecord", subRecord1Schema));
+                createField("subRecord", subRecord1Schema));
 
         Schema record2Schema = createRecord("test",
-            createField("subRecord", subRecord2Schema));
+                createField("subRecord", subRecord2Schema));
 
         GenericRecordBuilder subSubRecordBuilder = new GenericRecordBuilder(subSubRecordSchema);
         subSubRecordBuilder.set("test1", "abc");
         subSubRecordBuilder.set("test2", "def");
-
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecord1Schema);
         subRecordBuilder.set("test1", "abc");
@@ -463,29 +466,27 @@ public class FastGenericDeserializerGeneratorTest {
         subRecordBuilder.set("test3", subSubRecordBuilder.build());
         subRecordBuilder.set("test4", "def");
 
-
         GenericRecordBuilder builder = new GenericRecordBuilder(record1Schema);
         builder.set("subRecord", subRecordBuilder.build());
 
         // when
-        GenericRecord record = decodeRecord(record1Schema, record2Schema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(record1Schema, record2Schema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", ((GenericRecord) record.get("subRecord")).get("test1"));
         Assert.assertEquals("def", ((GenericRecord) record.get("subRecord")).get("test4"));
     }
 
-
     @Test
     public void shouldReadMultipleChoiceUnion() {
         // given
         Schema subRecordSchema = createRecord("subRecord",
-            createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));
 
         Schema recordSchema = createRecord(
-            "test",
-            createUnionField("union", subRecordSchema, Schema.create(Schema.Type.STRING),
-                Schema.create(Schema.Type.INT)));
+                "test",
+                createUnionField("union", subRecordSchema, Schema.create(Schema.Type.STRING),
+                        Schema.create(Schema.Type.INT)));
 
         GenericRecordBuilder subRecordBuilder = new GenericRecordBuilder(subRecordSchema);
         subRecordBuilder.set("subField", "abc");
@@ -494,7 +495,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("union", subRecordBuilder.build());
 
         // when
-        GenericRecord record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        GenericRecord record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", ((GenericData.Record) record.get("union")).get("subField"));
@@ -504,7 +505,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("union", "abc");
 
         // when
-        record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals("abc", record.get("union"));
@@ -514,7 +515,7 @@ public class FastGenericDeserializerGeneratorTest {
         builder.set("union", 1);
 
         // when
-        record = decodeRecord(recordSchema, recordSchema, genericDataAsDecoder(builder.build()));
+        record = deserializeGenericFast(recordSchema, recordSchema, serializeGeneric(builder.build()));
 
         // then
         Assert.assertEquals(1, record.get("union"));
@@ -525,7 +526,7 @@ public class FastGenericDeserializerGeneratorTest {
     public void shouldReadArrayOfRecords() {
         // given
         Schema recordSchema = createRecord("record",
-            createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));
 
         Schema arrayRecordSchema = Schema.createArray(recordSchema);
 
@@ -537,8 +538,8 @@ public class FastGenericDeserializerGeneratorTest {
         recordsArray.add(subRecordBuilder.build());
 
         // when
-        GenericData.Array<GenericRecord> array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
-            genericDataAsDecoder(recordsArray));
+        GenericData.Array<GenericRecord> array = deserializeGenericFast(arrayRecordSchema, arrayRecordSchema,
+                serializeGeneric(recordsArray));
 
         // then
         Assert.assertEquals(2, array.size());
@@ -557,7 +558,7 @@ public class FastGenericDeserializerGeneratorTest {
         recordsArray.add(subRecordBuilder.build());
 
         // when
-        array = decodeRecord(arrayRecordSchema, arrayRecordSchema, genericDataAsDecoder(recordsArray));
+        array = deserializeGenericFast(arrayRecordSchema, arrayRecordSchema, serializeGeneric(recordsArray));
 
         // then
         Assert.assertEquals(2, array.size());
@@ -569,7 +570,7 @@ public class FastGenericDeserializerGeneratorTest {
     public void shouldReadMapOfRecords() {
         // given
         Schema recordSchema = createRecord("record",
-            createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));
+                createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));
 
         Schema mapRecordSchema = Schema.createMap(recordSchema);
 
@@ -581,8 +582,8 @@ public class FastGenericDeserializerGeneratorTest {
         recordsMap.put("2", subRecordBuilder.build());
 
         // when
-        Map<String, GenericRecord> map = decodeRecord(mapRecordSchema, mapRecordSchema,
-            FastSerdeTestsSupport.genericDataAsDecoder(recordsMap, mapRecordSchema));
+        Map<String, GenericRecord> map = deserializeGenericFast(mapRecordSchema, mapRecordSchema,
+                serializeGeneric(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
@@ -600,7 +601,7 @@ public class FastGenericDeserializerGeneratorTest {
         recordsMap.put("2", subRecordBuilder.build());
 
         // when
-        map = decodeRecord(mapRecordSchema, mapRecordSchema, FastSerdeTestsSupport.genericDataAsDecoder(recordsMap, mapRecordSchema));
+        map = deserializeGenericFast(mapRecordSchema, mapRecordSchema, serializeGeneric(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
@@ -608,9 +609,53 @@ public class FastGenericDeserializerGeneratorTest {
         Assert.assertEquals("abc", map.get("2").get("field"));
     }
 
-    public <T> T decodeRecord(Schema writerSchema, Schema readerSchema, Decoder decoder) {
+    @Test
+    public void shouldDeserializeNullElementInMap() {
+        // given
+        Schema mapRecordSchema = Schema.createMap(Schema.createUnion(
+                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+
+        Map<String, Object> records = new HashMap<>();
+        records.put("0", "0");
+        records.put("1", null);
+        records.put("2", 2);
+
+        // when
+        Map<String, Object> map = deserializeGenericFast(mapRecordSchema, mapRecordSchema,
+                serializeGeneric(records, mapRecordSchema));
+
+        // then
+        Assert.assertEquals(3, map.size());
+        Assert.assertEquals("0", map.get("0"));
+        Assert.assertNull(map.get("1"));
+        Assert.assertEquals(2, map.get("2"));
+    }
+
+    @Test
+    public void shouldDeserializeNullElementInArray() {
+        // given
+        Schema arrayRecordSchema = Schema.createArray(Schema.createUnion(
+                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+
+        List<Object> records = new ArrayList<>();
+        records.add("0");
+        records.add(null);
+        records.add(2);
+
+        // when
+        List<Object> array = deserializeGenericFast(arrayRecordSchema, arrayRecordSchema,
+                serializeGeneric(records, arrayRecordSchema));
+
+        // then
+        Assert.assertEquals(3, array.size());
+        Assert.assertEquals("0", array.get(0));
+        Assert.assertNull(array.get(1));
+        Assert.assertEquals(2, array.get(2));
+    }
+
+    private <T> T deserializeGenericFast(Schema writerSchema, Schema readerSchema, Decoder decoder) {
         FastDeserializer<T> deserializer = new FastGenericDeserializerGenerator<T>(writerSchema,
-            readerSchema, tempDir, classLoader, null).generateDeserializer();
+                readerSchema, tempDir, classLoader, null).generateDeserializer();
 
         try {
             return deserializer.deserialize(decoder);
@@ -618,6 +663,5 @@ public class FastGenericDeserializerGeneratorTest {
             throw new RuntimeException(e);
         }
     }
-
 
 }

--- a/src/test/java/com/rtbhouse/utils/avro/FastSpecificDeserializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastSpecificDeserializerGeneratorTest.java
@@ -40,8 +40,8 @@ public class FastSpecificDeserializerGeneratorTest {
         Path tempPath = Files.createTempDirectory("generated");
         tempDir = tempPath.toFile();
 
-        classLoader = URLClassLoader.newInstance(new URL[]{ tempDir.toURI().toURL() },
-            FastSpecificDeserializerGeneratorTest.class.getClassLoader());
+        classLoader = URLClassLoader.newInstance(new URL[] { tempDir.toURI().toURL() },
+                FastSpecificDeserializerGeneratorTest.class.getClassLoader());
     }
 
     @Test
@@ -59,8 +59,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("testFloatUnion", 1.0f);
         record.put("testBoolean", true);
         record.put("testBooleanUnion", true);
-        record.put("testBytes", ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }));
-        record.put("testBytesUnion", ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }));
+        record.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
+        record.put("testBytesUnion", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
 
         // when
         record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
@@ -78,8 +78,8 @@ public class FastSpecificDeserializerGeneratorTest {
         Assert.assertEquals(1.0f, record.get("testFloatUnion"));
         Assert.assertEquals(true, record.get("testBoolean"));
         Assert.assertEquals(true, record.get("testBooleanUnion"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytes"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytesUnion"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytes"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytesUnion"));
 
     }
 
@@ -88,19 +88,19 @@ public class FastSpecificDeserializerGeneratorTest {
         // given
         TestRecord record = emptyTestRecord();
 
-        record.put("testFixed", new TestFixed(new byte[]{0x01}));
-        record.put("testFixedUnion", new TestFixed(new byte[]{0x02}));
-        record.put("testFixedArray", Arrays.asList(new TestFixed(new byte[]{0x03})));
-        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[]{0x04})));
+        record.put("testFixed", new TestFixed(new byte[] { 0x01 }));
+        record.put("testFixedUnion", new TestFixed(new byte[] { 0x02 }));
+        record.put("testFixedArray", Arrays.asList(new TestFixed(new byte[] { 0x03 })));
+        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[] { 0x04 })));
 
         // when
         record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
 
         // then
-        Assert.assertArrayEquals(new byte[]{ 0x01 }, record.getTestFixed().bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x02 }, record.getTestFixedUnion().bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x03 }, record.getTestFixedArray().get(0).bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x04 }, record.getTestFixedUnionArray().get(0).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x01 }, record.getTestFixed().bytes());
+        Assert.assertArrayEquals(new byte[] { 0x02 }, record.getTestFixedUnion().bytes());
+        Assert.assertArrayEquals(new byte[] { 0x03 }, record.getTestFixedArray().get(0).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x04 }, record.getTestFixedUnionArray().get(0).bytes());
     }
 
     @Test
@@ -124,11 +124,12 @@ public class FastSpecificDeserializerGeneratorTest {
     }
 
     @Test
-    public void shouldReadPermutatedEnum() throws IOException {
+    public void shouldReadPermutedEnum() throws IOException {
         // given
         Schema.Parser parser = new Schema.Parser();
         Schema oldRecordSchema = parser.parse(this.getClass().getResourceAsStream("/schema/fastserdetestold.avsc"));
-        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(), new byte[]{0x01});
+        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(),
+                new byte[] { 0x01 });
         GenericData.Record subRecord = new GenericData.Record(oldRecordSchema.getField("subRecordUnion").schema()
                 .getTypes().get(1));
         GenericData.Record oldRecord = new GenericData.Record(oldRecordSchema);
@@ -136,8 +137,8 @@ public class FastSpecificDeserializerGeneratorTest {
         oldRecord.put("testLong", 1l);
         oldRecord.put("testDouble", 1.0);
         oldRecord.put("testFloat", 1.0f);
-        oldRecord.put("testBoolean",true);
-        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        oldRecord.put("testBoolean", true);
+        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
         oldRecord.put("testString", "aaa");
         oldRecord.put("testFixed", testFixed);
         oldRecord.put("testFixedUnion", testFixed);
@@ -174,8 +175,9 @@ public class FastSpecificDeserializerGeneratorTest {
         // given
         Schema.Parser parser = new Schema.Parser();
         Schema oldRecordSchema = parser.parse(this.getClass().getResourceAsStream(
-            "/schema/fastserdetestoldextendedenum.avsc"));
-        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(), new byte[]{0x01});
+                "/schema/fastserdetestoldextendedenum.avsc"));
+        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(),
+                new byte[] { 0x01 });
         GenericData.Record subRecord = new GenericData.Record(oldRecordSchema.getField("subRecordUnion").schema()
                 .getTypes().get(1));
         GenericData.Record oldRecord = new GenericData.Record(oldRecordSchema);
@@ -183,8 +185,8 @@ public class FastSpecificDeserializerGeneratorTest {
         oldRecord.put("testLong", 1l);
         oldRecord.put("testDouble", 1.0);
         oldRecord.put("testFloat", 1.0f);
-        oldRecord.put("testBoolean",true);
-        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        oldRecord.put("testBoolean", true);
+        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
         oldRecord.put("testString", "aaa");
         oldRecord.put("testFixed", testFixed);
         oldRecord.put("testFixedUnion", testFixed);
@@ -303,15 +305,17 @@ public class FastSpecificDeserializerGeneratorTest {
         Schema oldRecordSchema = parser.parse(this.getClass().getResourceAsStream("/schema/fastserdetestold.avsc"));
         GenericData.Record subRecord = new GenericData.Record(oldRecordSchema.getField("subRecordUnion").schema()
                 .getTypes().get(1));
-        GenericData.EnumSymbol testEnum = new GenericData.EnumSymbol(oldRecordSchema.getField("testEnum").schema(), "A");
-        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(), new byte[]{0x01});
+        GenericData.EnumSymbol testEnum = new GenericData.EnumSymbol(oldRecordSchema.getField("testEnum").schema(),
+                "A");
+        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(),
+                new byte[] { 0x01 });
         GenericData.Record oldRecord = new GenericData.Record(oldRecordSchema);
         oldRecord.put("testInt", 1);
         oldRecord.put("testLong", 1l);
         oldRecord.put("testDouble", 1.0);
         oldRecord.put("testFloat", 1.0f);
-        oldRecord.put("testBoolean",true);
-        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        oldRecord.put("testBoolean", true);
+        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
         oldRecord.put("testString", "aaa");
         oldRecord.put("testFixed", testFixed);
         oldRecord.put("testFixedUnion", testFixed);
@@ -348,15 +352,17 @@ public class FastSpecificDeserializerGeneratorTest {
 
         GenericData.Record subRecord = new GenericData.Record(oldRecordSchema.getField("subRecordUnion").schema()
                 .getTypes().get(1));
-        GenericData.EnumSymbol testEnum = new GenericData.EnumSymbol(oldRecordSchema.getField("testEnum").schema(), "A");
-        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(), new byte[]{0x01});
+        GenericData.EnumSymbol testEnum = new GenericData.EnumSymbol(oldRecordSchema.getField("testEnum").schema(),
+                "A");
+        GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(),
+                new byte[] { 0x01 });
         GenericData.Record oldRecord = new GenericData.Record(oldRecordSchema);
         oldRecord.put("testInt", 1);
         oldRecord.put("testLong", 1l);
         oldRecord.put("testDouble", 1.0);
         oldRecord.put("testFloat", 1.0f);
-        oldRecord.put("testBoolean",true);
-        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        oldRecord.put("testBoolean", true);
+        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
         oldRecord.put("testString", "aaa");
         oldRecord.put("testStringAlias", "abc");
         oldRecord.put("removedField", "def");
@@ -440,7 +446,7 @@ public class FastSpecificDeserializerGeneratorTest {
 
         // when
         List<TestRecord> array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
-            specificDataAsDecoder(recordsArray, arrayRecordSchema));
+                specificDataAsDecoder(recordsArray, arrayRecordSchema));
 
         // then
         Assert.assertEquals(2, array.size());
@@ -459,7 +465,8 @@ public class FastSpecificDeserializerGeneratorTest {
         recordsArray.add(testRecord);
 
         // when
-        array = decodeRecord(arrayRecordSchema, arrayRecordSchema, specificDataAsDecoder(recordsArray, arrayRecordSchema));
+        array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
+                specificDataAsDecoder(recordsArray, arrayRecordSchema));
 
         // then
         Assert.assertEquals(2, array.size());
@@ -490,7 +497,7 @@ public class FastSpecificDeserializerGeneratorTest {
 
         // given
         mapRecordSchema = Schema.createMap(FastSerdeTestsSupport.createUnionSchema(TestRecord
-            .getClassSchema()));
+                .getClassSchema()));
 
         testRecord = emptyTestRecord();
         testRecord.put("testStringUnion", "abc");
@@ -506,6 +513,50 @@ public class FastSpecificDeserializerGeneratorTest {
         Assert.assertEquals(2, map.size());
         Assert.assertEquals("abc", map.get("1").get("testStringUnion"));
         Assert.assertEquals("abc", map.get("2").get("testStringUnion"));
+    }
+
+    @Test
+    public void testNullElementMap() {
+        // given
+        Schema mapRecordSchema = Schema.createMap(Schema.createUnion(
+                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+
+        Map<String, Object> records = new HashMap<>();
+        records.put("0", "0");
+        records.put("1", null);
+        records.put("2", 2);
+
+        // when
+        Map<String, Object> map = decodeRecord(mapRecordSchema, mapRecordSchema,
+                specificDataAsDecoder(records, mapRecordSchema));
+
+        // then
+        Assert.assertEquals(3, map.size());
+        Assert.assertEquals("0", map.get("0"));
+        Assert.assertNull(map.get("1"));
+        Assert.assertEquals(2, map.get("2"));
+    }
+
+    @Test
+    public void testNullElementArray() {
+        // given
+        Schema arrayRecordSchema = Schema.createArray(Schema.createUnion(
+                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+
+        List<Object> records = new ArrayList<>();
+        records.add("0");
+        records.add(null);
+        records.add(2);
+
+        // when
+        List<Object> array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
+                specificDataAsDecoder(records, arrayRecordSchema));
+
+        // then
+        Assert.assertEquals(3, array.size());
+        Assert.assertEquals("0", array.get(0));
+        Assert.assertNull(array.get(1));
+        Assert.assertEquals(2, array.get(2));
     }
 
     @SuppressWarnings("unchecked")
@@ -524,9 +575,9 @@ public class FastSpecificDeserializerGeneratorTest {
     public static TestRecord emptyTestRecord() {
         TestRecord record = new TestRecord();
 
-        record.put("testFixed", new TestFixed(new byte[]{0x01}));
+        record.put("testFixed", new TestFixed(new byte[] { 0x01 }));
         record.put("testFixedArray", Collections.EMPTY_LIST);
-        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[]{0x01})));
+        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[] { 0x01 })));
 
         record.put("testEnum", TestEnum.A);
         record.put("testEnumArray", Collections.EMPTY_LIST);
@@ -544,7 +595,7 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("testFloat", 1.0f);
         record.put("testBoolean", true);
         record.put("testString", "aaa");
-        record.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        record.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
 
         return record;
     }

--- a/src/test/java/com/rtbhouse/utils/avro/FastSpecificDeserializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastSpecificDeserializerGeneratorTest.java
@@ -1,8 +1,9 @@
 package com.rtbhouse.utils.avro;
 
 import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.createUnionSchema;
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.genericDataAsDecoder;
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.specificDataAsDecoder;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.emptyTestRecord;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeGeneric;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeSpecific;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +64,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("testBytesUnion", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals(1, record.get("testInt"));
@@ -94,7 +96,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[] { 0x04 })));
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertArrayEquals(new byte[] { 0x01 }, record.getTestFixed().bytes());
@@ -114,7 +117,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("testEnumUnionArray", Arrays.asList(TestEnum.A));
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals(TestEnum.A, record.getTestEnum());
@@ -160,8 +164,8 @@ public class FastSpecificDeserializerGeneratorTest {
         oldRecord.put("recordsMapArray", Collections.emptyMap());
 
         // when
-        TestRecord record = decodeRecord(TestRecord.getClassSchema(), oldRecordSchema,
-                genericDataAsDecoder(oldRecord));
+        TestRecord record = deserializeSpecificFast(TestRecord.getClassSchema(), oldRecordSchema,
+                serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals(TestEnum.A, record.getTestEnum());
@@ -206,8 +210,8 @@ public class FastSpecificDeserializerGeneratorTest {
         oldRecord.put("recordsMapArray", Collections.emptyMap());
 
         // when
-        TestRecord record = decodeRecord(TestRecord.getClassSchema(), oldRecordSchema,
-                genericDataAsDecoder(oldRecord));
+        TestRecord record = deserializeSpecificFast(TestRecord.getClassSchema(), oldRecordSchema,
+                serializeGeneric(oldRecord));
     }
 
     @Test
@@ -221,7 +225,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("subRecord", subRecord);
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals("abc",
@@ -248,7 +253,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("recordsMapUnion", recordsMap);
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals("abc",
@@ -285,7 +291,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("recordsMapArrayUnion", recordsMapArray);
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals("abc", record.getRecordsArrayMap().get(0).get("1").getSubField());
@@ -337,8 +344,8 @@ public class FastSpecificDeserializerGeneratorTest {
         oldRecord.put("testStringAlias", "abc");
 
         // when
-        TestRecord record = decodeRecord(TestRecord.getClassSchema(), oldRecordSchema,
-                genericDataAsDecoder(oldRecord));
+        TestRecord record = deserializeSpecificFast(TestRecord.getClassSchema(), oldRecordSchema,
+                serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals("abc", record.getTestStringUnion());
@@ -388,8 +395,8 @@ public class FastSpecificDeserializerGeneratorTest {
         oldRecord.put("recordsMapArray", Collections.emptyMap());
 
         // when
-        TestRecord record = decodeRecord(TestRecord.getClassSchema(), oldRecordSchema,
-                genericDataAsDecoder(oldRecord));
+        TestRecord record = deserializeSpecificFast(TestRecord.getClassSchema(), oldRecordSchema,
+                serializeGeneric(oldRecord));
 
         // then
         Assert.assertEquals("abc", record.getTestStringUnion());
@@ -408,7 +415,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("union", subRecord);
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals("abc", ((SubRecord) record.getUnion()).getSubField());
@@ -417,7 +425,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("union", "abc");
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals("abc", record.getUnion());
@@ -426,7 +435,8 @@ public class FastSpecificDeserializerGeneratorTest {
         record.put("union", 1);
 
         // when
-        record = decodeRecord(TestRecord.getClassSchema(), TestRecord.getClassSchema(), specificDataAsDecoder(record));
+        record = deserializeSpecificFast(TestRecord.getClassSchema(), TestRecord.getClassSchema(),
+                serializeSpecific(record));
 
         // then
         Assert.assertEquals(1, record.getUnion());
@@ -445,8 +455,8 @@ public class FastSpecificDeserializerGeneratorTest {
         recordsArray.add(testRecord);
 
         // when
-        List<TestRecord> array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
-                specificDataAsDecoder(recordsArray, arrayRecordSchema));
+        List<TestRecord> array = deserializeSpecificFast(arrayRecordSchema, arrayRecordSchema,
+                serializeSpecific(recordsArray, arrayRecordSchema));
 
         // then
         Assert.assertEquals(2, array.size());
@@ -465,8 +475,8 @@ public class FastSpecificDeserializerGeneratorTest {
         recordsArray.add(testRecord);
 
         // when
-        array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
-                specificDataAsDecoder(recordsArray, arrayRecordSchema));
+        array = deserializeSpecificFast(arrayRecordSchema, arrayRecordSchema,
+                serializeSpecific(recordsArray, arrayRecordSchema));
 
         // then
         Assert.assertEquals(2, array.size());
@@ -487,8 +497,8 @@ public class FastSpecificDeserializerGeneratorTest {
         recordsMap.put("2", testRecord);
 
         // when
-        Map<String, TestRecord> map = decodeRecord(mapRecordSchema, mapRecordSchema,
-                specificDataAsDecoder(recordsMap, mapRecordSchema));
+        Map<String, TestRecord> map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
+                serializeSpecific(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
@@ -496,7 +506,7 @@ public class FastSpecificDeserializerGeneratorTest {
         Assert.assertEquals("abc", map.get("2").get("testStringUnion"));
 
         // given
-        mapRecordSchema = Schema.createMap(FastSerdeTestsSupport.createUnionSchema(TestRecord
+        mapRecordSchema = Schema.createMap(createUnionSchema(TestRecord
                 .getClassSchema()));
 
         testRecord = emptyTestRecord();
@@ -507,7 +517,8 @@ public class FastSpecificDeserializerGeneratorTest {
         recordsMap.put("2", testRecord);
 
         // when
-        map = decodeRecord(mapRecordSchema, mapRecordSchema, specificDataAsDecoder(recordsMap, mapRecordSchema));
+        map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
+                serializeSpecific(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
@@ -516,7 +527,7 @@ public class FastSpecificDeserializerGeneratorTest {
     }
 
     @Test
-    public void testNullElementMap() {
+    public void shouldDeserializeNullElementInMap() {
         // given
         Schema mapRecordSchema = Schema.createMap(Schema.createUnion(
                 Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
@@ -527,8 +538,8 @@ public class FastSpecificDeserializerGeneratorTest {
         records.put("2", 2);
 
         // when
-        Map<String, Object> map = decodeRecord(mapRecordSchema, mapRecordSchema,
-                specificDataAsDecoder(records, mapRecordSchema));
+        Map<String, Object> map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
+                serializeSpecific(records, mapRecordSchema));
 
         // then
         Assert.assertEquals(3, map.size());
@@ -538,7 +549,7 @@ public class FastSpecificDeserializerGeneratorTest {
     }
 
     @Test
-    public void testNullElementArray() {
+    public void shouldDeserializeNullElementInArray() {
         // given
         Schema arrayRecordSchema = Schema.createArray(Schema.createUnion(
                 Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
@@ -549,8 +560,8 @@ public class FastSpecificDeserializerGeneratorTest {
         records.add(2);
 
         // when
-        List<Object> array = decodeRecord(arrayRecordSchema, arrayRecordSchema,
-                specificDataAsDecoder(records, arrayRecordSchema));
+        List<Object> array = deserializeSpecificFast(arrayRecordSchema, arrayRecordSchema,
+                serializeSpecific(records, arrayRecordSchema));
 
         // then
         Assert.assertEquals(3, array.size());
@@ -560,8 +571,7 @@ public class FastSpecificDeserializerGeneratorTest {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T decodeRecord(Schema readerSchema, Schema writerSchema,
-            Decoder decoder) {
+    private <T> T deserializeSpecificFast(Schema readerSchema, Schema writerSchema, Decoder decoder) {
         FastDeserializer<T> deserializer = new FastSpecificDeserializerGenerator(writerSchema,
                 readerSchema, tempDir, classLoader, null).generateDeserializer();
 
@@ -572,31 +582,4 @@ public class FastSpecificDeserializerGeneratorTest {
         }
     }
 
-    public static TestRecord emptyTestRecord() {
-        TestRecord record = new TestRecord();
-
-        record.put("testFixed", new TestFixed(new byte[] { 0x01 }));
-        record.put("testFixedArray", Collections.EMPTY_LIST);
-        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[] { 0x01 })));
-
-        record.put("testEnum", TestEnum.A);
-        record.put("testEnumArray", Collections.EMPTY_LIST);
-        record.put("testEnumUnionArray", Arrays.asList(TestEnum.A));
-        record.put("subRecord", new SubRecord());
-
-        record.put("recordsArray", Collections.emptyList());
-        record.put("recordsArrayMap", Collections.emptyList());
-        record.put("recordsMap", Collections.emptyMap());
-        record.put("recordsMapArray", Collections.emptyMap());
-
-        record.put("testInt", 1);
-        record.put("testLong", 1l);
-        record.put("testDouble", 1.0);
-        record.put("testFloat", 1.0f);
-        record.put("testBoolean", true);
-        record.put("testString", "aaa");
-        record.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
-
-        return record;
-    }
 }

--- a/src/test/java/com/rtbhouse/utils/avro/FastSpecificSerializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastSpecificSerializerGeneratorTest.java
@@ -62,8 +62,8 @@ public class FastSpecificSerializerGeneratorTest {
         record.put("testFloatUnion", 1.0f);
         record.put("testBoolean", true);
         record.put("testBooleanUnion", true);
-        record.put("testBytes", ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }));
-        record.put("testBytesUnion", ByteBuffer.wrap(new byte[]{ 0x01, 0x02 }));
+        record.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
+        record.put("testBytesUnion", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
 
         // when
         record = decodeRecord(TestRecord.getClassSchema(), dataAsDecoder(record));
@@ -81,8 +81,8 @@ public class FastSpecificSerializerGeneratorTest {
         Assert.assertEquals(1.0f, record.get("testFloatUnion"));
         Assert.assertEquals(true, record.get("testBoolean"));
         Assert.assertEquals(true, record.get("testBooleanUnion"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytes"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytesUnion"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytes"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytesUnion"));
 
     }
 
@@ -91,19 +91,19 @@ public class FastSpecificSerializerGeneratorTest {
         // given
         TestRecord record = emptyTestRecord();
 
-        record.put("testFixed", new TestFixed(new byte[]{0x01}));
-        record.put("testFixedUnion", new TestFixed(new byte[]{0x02}));
-        record.put("testFixedArray", Arrays.asList(new TestFixed(new byte[]{0x03})));
-        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[]{0x04})));
+        record.put("testFixed", new TestFixed(new byte[] { 0x01 }));
+        record.put("testFixedUnion", new TestFixed(new byte[] { 0x02 }));
+        record.put("testFixedArray", Arrays.asList(new TestFixed(new byte[] { 0x03 })));
+        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[] { 0x04 })));
 
         // when
         record = decodeRecord(TestRecord.getClassSchema(), dataAsDecoder(record));
 
         // then
-        Assert.assertArrayEquals(new byte[]{ 0x01 }, record.getTestFixed().bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x02 }, record.getTestFixedUnion().bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x03 }, record.getTestFixedArray().get(0).bytes());
-        Assert.assertArrayEquals(new byte[]{ 0x04 }, record.getTestFixedUnionArray().get(0).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x01 }, record.getTestFixed().bytes());
+        Assert.assertArrayEquals(new byte[] { 0x02 }, record.getTestFixedUnion().bytes());
+        Assert.assertArrayEquals(new byte[] { 0x03 }, record.getTestFixedArray().get(0).bytes());
+        Assert.assertArrayEquals(new byte[] { 0x04 }, record.getTestFixedUnionArray().get(0).bytes());
     }
 
     @Test
@@ -300,7 +300,7 @@ public class FastSpecificSerializerGeneratorTest {
         recordsMap.put("2", testRecord);
 
         // when
-        Map<String, TestRecord> map = decodeRecord(mapRecordSchema, dataAsDecoder(recordsMap, mapRecordSchema));
+        Map<Utf8, TestRecord> map = decodeRecord(mapRecordSchema, dataAsDecoder(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
@@ -325,6 +325,48 @@ public class FastSpecificSerializerGeneratorTest {
         Assert.assertEquals(2, map.size());
         Assert.assertEquals("abc", map.get(new Utf8("1")).get("testString"));
         Assert.assertEquals("abc", map.get(new Utf8("2")).get("testString"));
+    }
+
+    @Test
+    public void testNullElementMap() {
+        // given
+        Schema mapRecordSchema = Schema.createMap(Schema.createUnion(
+                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+
+        Map<String, Object> records = new HashMap<>();
+        records.put("0", "0");
+        records.put("1", null);
+        records.put("2", 2);
+
+        // when
+        Map<Utf8, Object> map = decodeRecord(mapRecordSchema, dataAsDecoder(records, mapRecordSchema));
+
+        // then
+        Assert.assertEquals(3, map.size());
+        Assert.assertEquals(new Utf8("0"), map.get(new Utf8("0")));
+        Assert.assertNull(map.get(new Utf8("1")));
+        Assert.assertEquals(2, map.get(new Utf8("2")));
+    }
+
+    @Test
+    public void testNullElementArray() {
+        // given
+        Schema arrayRecordSchema = Schema.createArray(Schema.createUnion(
+                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+
+        List<Object> records = new ArrayList<>();
+        records.add("0");
+        records.add(null);
+        records.add(2);
+
+        // when
+        List<Object> array = decodeRecord(arrayRecordSchema, dataAsDecoder(records, arrayRecordSchema));
+
+        // then
+        Assert.assertEquals(3, array.size());
+        Assert.assertEquals(new Utf8("0"), array.get(0));
+        Assert.assertNull(array.get(1));
+        Assert.assertEquals(2, array.get(2));
     }
 
     public <T extends GenericContainer> Decoder dataAsDecoder(T data) {
@@ -363,9 +405,9 @@ public class FastSpecificSerializerGeneratorTest {
     public static TestRecord emptyTestRecord() {
         TestRecord record = new TestRecord();
 
-        record.put("testFixed", new TestFixed(new byte[]{0x01}));
+        record.put("testFixed", new TestFixed(new byte[] { 0x01 }));
         record.put("testFixedArray", Collections.EMPTY_LIST);
-        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[]{0x01})));
+        record.put("testFixedUnionArray", Arrays.asList(new TestFixed(new byte[] { 0x01 })));
 
         record.put("testEnum", TestEnum.A);
         record.put("testEnumArray", Collections.EMPTY_LIST);
@@ -383,7 +425,7 @@ public class FastSpecificSerializerGeneratorTest {
         record.put("testFloat", 1.0f);
         record.put("testBoolean", true);
         record.put("testString", "aaa");
-        record.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        record.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
 
         return record;
     }

--- a/src/test/java/com/rtbhouse/utils/avro/FastStringableTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastStringableTest.java
@@ -1,5 +1,8 @@
 package com.rtbhouse.utils.avro;
 
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.deserializeSpecific;
+import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.serializeSpecific;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.math.BigDecimal;
@@ -22,9 +25,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.specificDataAsDecoder;
-import static com.rtbhouse.utils.avro.FastSerdeTestsSupport.specificDataFromDecoder;
-
 import com.rtbhouse.utils.generated.avro.AnotherSubRecord;
 import com.rtbhouse.utils.generated.avro.StringableRecord;
 import com.rtbhouse.utils.generated.avro.StringableSubRecord;
@@ -43,7 +43,67 @@ public class FastStringableTest {
                 FastDeserializerDefaultsTest.class.getClassLoader());
     }
 
-    StringableRecord generateRecord(URL exampleURL, URI exampleURI, File exampleFile,
+    @Test
+    public void shouldSerializeStringableFields() throws URISyntaxException, MalformedURLException {
+
+        // given
+        BigInteger exampleBigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE)).pow(16);
+        BigDecimal exampleBigDecimal = new BigDecimal(Double.MIN_VALUE).pow(16);
+        File exampleFile = new File("/tmp/test");
+        URI exampleURI = new URI("urn:ISSN:1522-3611");
+        URL exampleURL = new URL("http://www.example.com");
+
+        StringableRecord record = generateRecord(exampleURL, exampleURI, exampleFile, exampleBigDecimal,
+                exampleBigInteger);
+
+        // when
+        StringableRecord afterDecoding = deserializeSpecific(StringableRecord.getClassSchema(),
+                serializeSpecificFast(record, StringableRecord.getClassSchema()));
+
+        // then
+        Assert.assertEquals(exampleBigDecimal, afterDecoding.getBigdecimal());
+        Assert.assertEquals(exampleBigInteger, afterDecoding.getBiginteger());
+        Assert.assertEquals(exampleFile, afterDecoding.getFile());
+        Assert.assertEquals(Collections.singletonList(exampleURL), afterDecoding.getUrlArray());
+        Assert.assertEquals(Collections.singletonMap(exampleURL, exampleBigInteger), afterDecoding.getUrlMap());
+        Assert.assertNotNull(afterDecoding.getSubRecord());
+        Assert.assertEquals(exampleURI, afterDecoding.getSubRecord().getUriField());
+        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord());
+        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord().getSubRecord());
+        Assert.assertEquals(exampleURI, afterDecoding.getSubRecordWithSubRecord().getSubRecord().getUriField());
+    }
+
+    @Test
+    public void shouldDeserializeStringableFields() throws URISyntaxException, MalformedURLException {
+
+        // given
+        BigInteger exampleBigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE)).pow(16);
+        BigDecimal exampleBigDecimal = new BigDecimal(Double.MIN_VALUE).pow(16);
+        File exampleFile = new File("/tmp/test");
+        URI exampleURI = new URI("urn:ISSN:1522-3611");
+        URL exampleURL = new URL("http://www.example.com");
+
+        StringableRecord record = generateRecord(exampleURL, exampleURI, exampleFile, exampleBigDecimal,
+                exampleBigInteger);
+
+        // when
+        StringableRecord afterDecoding = deserializeSpecificFast(StringableRecord.getClassSchema(),
+                StringableRecord.getClassSchema(), serializeSpecific(record));
+
+        // then
+        Assert.assertEquals(exampleBigDecimal, afterDecoding.getBigdecimal());
+        Assert.assertEquals(exampleBigInteger, afterDecoding.getBiginteger());
+        Assert.assertEquals(exampleFile, afterDecoding.getFile());
+        Assert.assertEquals(Collections.singletonList(exampleURL), afterDecoding.getUrlArray());
+        Assert.assertEquals(Collections.singletonMap(exampleURL, exampleBigInteger), afterDecoding.getUrlMap());
+        Assert.assertNotNull(afterDecoding.getSubRecord());
+        Assert.assertEquals(exampleURI, afterDecoding.getSubRecord().getUriField());
+        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord());
+        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord().getSubRecord());
+        Assert.assertEquals(exampleURI, afterDecoding.getSubRecordWithSubRecord().getSubRecord().getUriField());
+    }
+
+    private StringableRecord generateRecord(URL exampleURL, URI exampleURI, File exampleFile,
             BigDecimal exampleBigDecimal, BigInteger exampleBigInteger) {
 
         StringableSubRecord subrecord = new StringableSubRecord();
@@ -64,63 +124,7 @@ public class FastStringableTest {
         return recordBuilder.build();
     }
 
-    @Test
-    public void serializeStringableFields() throws URISyntaxException, MalformedURLException {
-
-        // given
-        BigInteger exampleBigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE)).pow(16);
-        BigDecimal exampleBigDecimal = new BigDecimal(Double.MIN_VALUE).pow(16);
-        File exampleFile = new File("/tmp/test");
-        URI exampleURI = new URI("urn:ISSN:1522-3611");
-        URL exampleURL = new URL("http://www.example.com");
-
-        StringableRecord record = generateRecord(exampleURL, exampleURI, exampleFile, exampleBigDecimal, exampleBigInteger);
-
-        // when
-        StringableRecord afterDecoding = specificDataFromDecoder(StringableRecord.getClassSchema(), writeWithFastAvro(record, StringableRecord.getClassSchema()));
-
-        // then
-        Assert.assertEquals(exampleBigDecimal, afterDecoding.getBigdecimal());
-        Assert.assertEquals(exampleBigInteger, afterDecoding.getBiginteger());
-        Assert.assertEquals(exampleFile, afterDecoding.getFile());
-        Assert.assertEquals(Collections.singletonList(exampleURL), afterDecoding.getUrlArray());
-        Assert.assertEquals(Collections.singletonMap(exampleURL, exampleBigInteger), afterDecoding.getUrlMap());
-        Assert.assertNotNull(afterDecoding.getSubRecord());
-        Assert.assertEquals(exampleURI, afterDecoding.getSubRecord().getUriField());
-        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord());
-        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord().getSubRecord());
-        Assert.assertEquals(exampleURI, afterDecoding.getSubRecordWithSubRecord().getSubRecord().getUriField());
-    }
-
-    @Test
-    public void deserializeStringableFields() throws URISyntaxException, MalformedURLException {
-
-        // given
-        BigInteger exampleBigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE)).pow(16);
-        BigDecimal exampleBigDecimal = new BigDecimal(Double.MIN_VALUE).pow(16);
-        File exampleFile = new File("/tmp/test");
-        URI exampleURI = new URI("urn:ISSN:1522-3611");
-        URL exampleURL = new URL("http://www.example.com");
-
-        StringableRecord record = generateRecord(exampleURL, exampleURI, exampleFile, exampleBigDecimal, exampleBigInteger);
-
-        // when
-        StringableRecord afterDecoding = readWithFastAvro(StringableRecord.getClassSchema(), StringableRecord.getClassSchema(), specificDataAsDecoder(record));
-
-        // then
-        Assert.assertEquals(exampleBigDecimal, afterDecoding.getBigdecimal());
-        Assert.assertEquals(exampleBigInteger, afterDecoding.getBiginteger());
-        Assert.assertEquals(exampleFile, afterDecoding.getFile());
-        Assert.assertEquals(Collections.singletonList(exampleURL), afterDecoding.getUrlArray());
-        Assert.assertEquals(Collections.singletonMap(exampleURL, exampleBigInteger), afterDecoding.getUrlMap());
-        Assert.assertNotNull(afterDecoding.getSubRecord());
-        Assert.assertEquals(exampleURI, afterDecoding.getSubRecord().getUriField());
-        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord());
-        Assert.assertNotNull(afterDecoding.getSubRecordWithSubRecord().getSubRecord());
-        Assert.assertEquals(exampleURI, afterDecoding.getSubRecordWithSubRecord().getSubRecord().getUriField());
-    }
-
-    public <T> Decoder writeWithFastAvro(T data, Schema schema) {
+    private <T> Decoder serializeSpecificFast(T data, Schema schema) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         BinaryEncoder binaryEncoder = EncoderFactory.get().directBinaryEncoder(baos, null);
 
@@ -138,7 +142,7 @@ public class FastStringableTest {
         return DecoderFactory.get().binaryDecoder(baos.toByteArray(), null);
     }
 
-    public <T> T readWithFastAvro(Schema writerSchema, Schema readerSchema, Decoder decoder) {
+    private <T> T deserializeSpecificFast(Schema writerSchema, Schema readerSchema, Decoder decoder) {
         FastDeserializer<T> deserializer = new FastSpecificDeserializerGenerator<T>(writerSchema,
                 readerSchema, tempDir, classLoader, null).generateDeserializer();
 


### PR DESCRIPTION
As stated in #11 we indeed had a bug in processing null elements in arrays of unions - nulls were just read from decoder and not added to array. This commit is fixing that behavior. 