### PR TITLE
added support for "avro.java.string" property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.rtbhouse</groupId>
     <artifactId>avro-fastserde</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>avro-fastserde</name>

--- a/src/test/java/com/rtbhouse/utils/avro/FastDatumReaderTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastDatumReaderTest.java
@@ -112,6 +112,6 @@ public class FastDatumReaderTest {
         Assert.assertNotEquals(2, fastGenericDeserializer.getClass().getDeclaredMethods().length);
         Assert.assertEquals(
                 "test",
-                fastGenericDatumReader.read(null, serializeGeneric(recordBuilder.build())).get("test"));
+                fastGenericDatumReader.read(null, serializeGeneric(recordBuilder.build())).get("test").toString());
     }
 }

--- a/src/test/java/com/rtbhouse/utils/avro/FastDeserializerDefaultsTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastDeserializerDefaultsTest.java
@@ -24,6 +24,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.util.Utf8;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class FastDeserializerDefaultsTest {
         Path tempPath = Files.createTempDirectory("generated");
         tempDir = tempPath.toFile();
 
-        classLoader = URLClassLoader.newInstance(new URL[] { tempDir.toURI().toURL() },
+        classLoader = URLClassLoader.newInstance(new URL[]{tempDir.toURI().toURL()},
                 FastDeserializerDefaultsTest.class.getClassLoader());
     }
 
@@ -81,14 +82,14 @@ public class FastDeserializerDefaultsTest {
         Assert.assertNull(testRecord.getTestFloatUnion());
         Assert.assertEquals(true, testRecord.getTestBoolean());
         Assert.assertNull(testRecord.getTestBooleanUnion());
-        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0, 1, 2, 3 }), testRecord.getTestBytes());
+        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0, 1, 2, 3}), testRecord.getTestBytes());
         Assert.assertNull(testRecord.getTestBytesUnion());
         Assert.assertEquals("testStringValue", testRecord.getTestString());
         Assert.assertEquals(new URL("http://www.example.com"), testRecord.getTestStringable());
         Assert.assertNull(testRecord.getTestStringUnion());
-        Assert.assertEquals(new DefaultsFixed(new byte[] { (byte) 0xFF }), testRecord.getTestFixed());
+        Assert.assertEquals(new DefaultsFixed(new byte[]{(byte) 0xFF}), testRecord.getTestFixed());
         Assert.assertNull(testRecord.getTestFixedUnion());
-        Assert.assertEquals(Collections.singletonList(new DefaultsFixed(new byte[] { (byte) 0xFA })),
+        Assert.assertEquals(Collections.singletonList(new DefaultsFixed(new byte[]{(byte) 0xFA})),
                 testRecord.getTestFixedArray());
 
         List listWithNull = new LinkedList();
@@ -157,17 +158,17 @@ public class FastDeserializerDefaultsTest {
         Assert.assertNull(testRecord.get("testFloatUnion"));
         Assert.assertEquals(true, testRecord.get("testBoolean"));
         Assert.assertNull(testRecord.get("testBooleanUnion"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0, 1, 2, 3 }), testRecord.get("testBytes"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0, 1, 2, 3}), testRecord.get("testBytes"));
         Assert.assertNull(testRecord.get("testBytesUnion"));
         Assert.assertEquals("testStringValue", testRecord.get("testString"));
         Assert.assertEquals("http://www.example.com", testRecord.get("testStringable"));
         Assert.assertNull(testRecord.get("testStringUnion"));
-        Assert.assertEquals(new GenericData.Fixed(DefaultsFixed.getClassSchema(), new byte[] { (byte) 0xFF }),
+        Assert.assertEquals(new GenericData.Fixed(DefaultsFixed.getClassSchema(), new byte[]{(byte) 0xFF}),
                 testRecord.get("testFixed"));
         Assert.assertNull(testRecord.get("testFixedUnion"));
         Assert.assertEquals(
                 Collections.singletonList(
-                        new GenericData.Fixed(DefaultsFixed.getClassSchema(), new byte[] { (byte) 0xFA })),
+                        new GenericData.Fixed(DefaultsFixed.getClassSchema(), new byte[]{(byte) 0xFA})),
                 testRecord.get("testFixedArray"));
 
         List listWithNull = new LinkedList();
@@ -259,7 +260,7 @@ public class FastDeserializerDefaultsTest {
         GenericData.EnumSymbol testEnum = new GenericData.EnumSymbol(
                 oldRecordSchema.getField("testEnum").schema(), "A");
         GenericData.Fixed testFixed = new GenericData.Fixed(oldRecordSchema.getField("testFixed").schema(),
-                new byte[] { 0x01 });
+                new byte[]{0x01});
         GenericData.Record oldRecord = new GenericData.Record(oldRecordSchema);
 
         oldRecord.put("testInt", 1);
@@ -267,7 +268,7 @@ public class FastDeserializerDefaultsTest {
         oldRecord.put("testDouble", 1.0);
         oldRecord.put("testFloat", 1.0f);
         oldRecord.put("testBoolean", true);
-        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
+        oldRecord.put("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
         oldRecord.put("testString", "aaa");
         oldRecord.put("testFixed", testFixed);
         oldRecord.put("testEnum", testEnum);
@@ -278,8 +279,8 @@ public class FastDeserializerDefaultsTest {
         oldRecord.put("subRecordUnion", subRecord);
         oldRecord.put("subRecord", subRecord);
         oldRecord.put("recordsArray", Collections.singletonList(subRecord));
-        Map<String, GenericData.Record> recordsMap = new HashMap<>();
-        recordsMap.put("1", subRecord);
+        Map<Utf8, GenericData.Record> recordsMap = new HashMap<>();
+        recordsMap.put(new Utf8("1"), subRecord);
         oldRecord.put("recordsMap", recordsMap);
 
         oldRecord.put("testFixedArray", Collections.emptyList());
@@ -300,7 +301,7 @@ public class FastDeserializerDefaultsTest {
         newSubRecord.put("subField", "abc");
         newSubRecord.put("anotherField", "ghi");
         newSubRecord.put("newSubField", "newSubFieldValue");
-        recordsMap.put("1", newSubRecord);
+        recordsMap.put(new Utf8("1"), newSubRecord);
 
         Assert.assertEquals("newSubFieldValue",
                 ((GenericRecord) record.get("subRecordUnion")).get("newSubField").toString());
@@ -310,8 +311,8 @@ public class FastDeserializerDefaultsTest {
         Assert.assertEquals(1.0, record.get("testDouble"));
         Assert.assertEquals(1.0f, record.get("testFloat"));
         Assert.assertEquals(true, record.get("testBoolean"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytes"));
-        Assert.assertEquals("aaa", record.get("testString"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytes"));
+        Assert.assertEquals("aaa", record.get("testString").toString());
         Assert.assertEquals(testFixed, record.get("testFixed"));
         Assert.assertEquals(testEnum, record.get("testEnum"));
         Assert.assertEquals(newSubRecord, record.get("subRecordUnion"));

--- a/src/test/java/com/rtbhouse/utils/avro/FastGenericSerializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastGenericSerializerGeneratorTest.java
@@ -48,18 +48,22 @@ public class FastGenericSerializerGeneratorTest {
         Path tempPath = Files.createTempDirectory("generated");
         tempDir = tempPath.toFile();
 
-        classLoader = URLClassLoader.newInstance(new URL[] { tempDir.toURI().toURL() },
+        classLoader = URLClassLoader.newInstance(new URL[]{tempDir.toURI().toURL()},
                 FastGenericSerializerGeneratorTest.class.getClassLoader());
     }
 
     @Test
     public void shouldWritePrimitives() {
         // given
+        Schema javaLangStringSchema = Schema.create(Schema.Type.STRING);
+        GenericData.setStringType(javaLangStringSchema, GenericData.StringType.String);
         Schema recordSchema = createRecord("testRecord",
                 createField("testInt", Schema.create(Schema.Type.INT)),
                 createPrimitiveUnionFieldSchema("testIntUnion", Schema.Type.INT),
                 createField("testString", Schema.create(Schema.Type.STRING)),
                 createPrimitiveUnionFieldSchema("testStringUnion", Schema.Type.STRING),
+                createField("testJavaString", javaLangStringSchema),
+                createUnionField("testJavaStringUnion", javaLangStringSchema),
                 createField("testLong", Schema.create(Schema.Type.LONG)),
                 createPrimitiveUnionFieldSchema("testLongUnion", Schema.Type.LONG),
                 createField("testDouble", Schema.create(Schema.Type.DOUBLE)),
@@ -76,16 +80,18 @@ public class FastGenericSerializerGeneratorTest {
         builder.set("testIntUnion", 1);
         builder.set("testString", "aaa");
         builder.set("testStringUnion", "aaa");
-        builder.set("testLong", 1l);
-        builder.set("testLongUnion", 1l);
+        builder.set("testJavaString", "aaa");
+        builder.set("testJavaStringUnion", "aaa");
+        builder.set("testLong", 1L);
+        builder.set("testLongUnion", 1L);
         builder.set("testDouble", 1.0);
         builder.set("testDoubleUnion", 1.0);
         builder.set("testFloat", 1.0f);
         builder.set("testFloatUnion", 1.0f);
         builder.set("testBoolean", true);
         builder.set("testBooleanUnion", true);
-        builder.set("testBytes", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
-        builder.set("testBytesUnion", ByteBuffer.wrap(new byte[] { 0x01, 0x02 }));
+        builder.set("testBytes", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
+        builder.set("testBytesUnion", ByteBuffer.wrap(new byte[]{0x01, 0x02}));
 
         // when
         GenericRecord record = deserializeGeneric(recordSchema, serializeGenericFast(builder.build()));
@@ -95,20 +101,23 @@ public class FastGenericSerializerGeneratorTest {
         Assert.assertEquals(1, record.get("testIntUnion"));
         Assert.assertEquals("aaa", record.get("testString").toString());
         Assert.assertEquals("aaa", record.get("testStringUnion").toString());
-        Assert.assertEquals(1l, record.get("testLong"));
-        Assert.assertEquals(1l, record.get("testLongUnion"));
+        Assert.assertEquals("aaa", record.get("testJavaString"));
+        Assert.assertEquals("aaa", record.get("testJavaStringUnion"));
+        Assert.assertEquals(1L, record.get("testLong"));
+        Assert.assertEquals(1L, record.get("testLongUnion"));
         Assert.assertEquals(1.0, record.get("testDouble"));
         Assert.assertEquals(1.0, record.get("testDoubleUnion"));
         Assert.assertEquals(1.0f, record.get("testFloat"));
         Assert.assertEquals(1.0f, record.get("testFloatUnion"));
         Assert.assertEquals(true, record.get("testBoolean"));
         Assert.assertEquals(true, record.get("testBooleanUnion"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytes"));
-        Assert.assertEquals(ByteBuffer.wrap(new byte[] { 0x01, 0x02 }), record.get("testBytesUnion"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytes"));
+        Assert.assertEquals(ByteBuffer.wrap(new byte[]{0x01, 0x02}), record.get("testBytesUnion"));
 
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldWriteFixed() {
         // given
         Schema fixedSchema = createFixedSchema("testFixed", 2);
@@ -117,28 +126,29 @@ public class FastGenericSerializerGeneratorTest {
                 createArrayFieldSchema("testFixedUnionArray", createUnionSchema(fixedSchema)));
 
         GenericRecordBuilder builder = new GenericRecordBuilder(recordSchema);
-        builder.set("testFixed", new GenericData.Fixed(fixedSchema, new byte[] { 0x01, 0x02 }));
-        builder.set("testFixedUnion", new GenericData.Fixed(fixedSchema, new byte[] { 0x03, 0x04 }));
-        builder.set("testFixedArray", Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[] { 0x05, 0x06 })));
+        builder.set("testFixed", new GenericData.Fixed(fixedSchema, new byte[]{0x01, 0x02}));
+        builder.set("testFixedUnion", new GenericData.Fixed(fixedSchema, new byte[]{0x03, 0x04}));
+        builder.set("testFixedArray", Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[]{0x05, 0x06})));
         builder.set("testFixedUnionArray",
-                Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[] { 0x07, 0x08 })));
+                Arrays.asList(new GenericData.Fixed(fixedSchema, new byte[]{0x07, 0x08})));
 
         // when
         GenericRecord record = deserializeGeneric(recordSchema, serializeGenericFast(builder.build()));
 
         // then
-        Assert.assertArrayEquals(new byte[] { 0x01, 0x02 }, ((GenericData.Fixed) record.get("testFixed")).bytes());
-        Assert.assertArrayEquals(new byte[] { 0x03, 0x04 }, ((GenericData.Fixed) record.get("testFixedUnion")).bytes());
-        Assert.assertArrayEquals(new byte[] { 0x05, 0x06 },
+        Assert.assertArrayEquals(new byte[]{0x01, 0x02}, ((GenericData.Fixed) record.get("testFixed")).bytes());
+        Assert.assertArrayEquals(new byte[]{0x03, 0x04}, ((GenericData.Fixed) record.get("testFixedUnion")).bytes());
+        Assert.assertArrayEquals(new byte[]{0x05, 0x06},
                 ((List<GenericData.Fixed>) record.get("testFixedArray")).get(0).bytes());
-        Assert.assertArrayEquals(new byte[] { 0x07, 0x08 },
+        Assert.assertArrayEquals(new byte[]{0x07, 0x08},
                 ((List<GenericData.Fixed>) record.get("testFixedUnionArray")).get(0).bytes());
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldWriteEnum() {
         // given
-        Schema enumSchema = createEnumSchema("testEnum", new String[] { "A", "B" });
+        Schema enumSchema = createEnumSchema("testEnum", new String[]{"A", "B"});
         Schema recordSchema = createRecord("testRecord", createField("testEnum", enumSchema),
                 createUnionField("testEnumUnion", enumSchema), createArrayFieldSchema("testEnumArray", enumSchema),
                 createArrayFieldSchema("testEnumUnionArray", createUnionSchema(enumSchema)));
@@ -188,6 +198,7 @@ public class FastGenericSerializerGeneratorTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldWriteSubRecordCollectionsField() {
         // given
         Schema subRecordSchema = createRecord("subRecord",
@@ -219,14 +230,15 @@ public class FastGenericSerializerGeneratorTest {
         Assert.assertEquals("abc",
                 ((List<GenericData.Record>) record.get("recordsArrayUnion")).get(0).get("subField").toString());
         Assert.assertEquals("abc",
-                ((Map<String, GenericData.Record>) record.get("recordsMap")).get(new Utf8("1")).get("subField")
+                ((Map<Utf8, GenericData.Record>) record.get("recordsMap")).get(new Utf8("1")).get("subField")
                         .toString());
         Assert.assertEquals("abc",
-                ((Map<String, GenericData.Record>) record.get("recordsMapUnion")).get(new Utf8("1")).get("subField")
+                ((Map<Utf8, GenericData.Record>) record.get("recordsMapUnion")).get(new Utf8("1")).get("subField")
                         .toString());
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldWriteSubRecordComplexCollectionsField() {
         // given
         Schema subRecordSchema = createRecord("subRecord",
@@ -303,7 +315,7 @@ public class FastGenericSerializerGeneratorTest {
 
         // given
         builder = new GenericRecordBuilder(recordSchema);
-        builder.set("union", "abc");
+        builder.set("union", new Utf8("abc"));
 
         // when
         record = deserializeGeneric(recordSchema, serializeGenericFast(builder.build()));
@@ -321,6 +333,90 @@ public class FastGenericSerializerGeneratorTest {
         // then
         Assert.assertEquals(1, record.get("union"));
 
+    }
+
+    @Test
+    public void shouldWriteArrayOfPrimitives() {
+        // given
+        Schema stringArraySchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+
+        GenericData.Array<String> stringArray = new GenericData.Array<>(0, stringArraySchema);
+        stringArray.add("aaa");
+        stringArray.add("abc");
+
+        Schema intArraySchema = Schema.createArray(Schema.create(Schema.Type.INT));
+
+        GenericData.Array<Integer> intArray = new GenericData.Array<>(0, intArraySchema);
+        intArray.add(1);
+        intArray.add(2);
+
+        Schema longArraySchema = Schema.createArray(Schema.create(Schema.Type.LONG));
+
+        GenericData.Array<Long> longArray = new GenericData.Array<>(0, longArraySchema);
+        longArray.add(1L);
+        longArray.add(2L);
+
+        Schema doubleArraySchema = Schema.createArray(Schema.create(Schema.Type.DOUBLE));
+
+        GenericData.Array<Double> doubleArray = new GenericData.Array<>(0, doubleArraySchema);
+        doubleArray.add(1.0);
+        doubleArray.add(2.0);
+
+        Schema floatArraySchema = Schema.createArray(Schema.create(Schema.Type.FLOAT));
+
+        GenericData.Array<Float> floatArray = new GenericData.Array<>(0, floatArraySchema);
+        floatArray.add(1.0f);
+        floatArray.add(2.0f);
+
+        Schema bytesArraySchema = Schema.createArray(Schema.create(Schema.Type.BYTES));
+
+        GenericData.Array<ByteBuffer> bytesArray = new GenericData.Array<>(0, bytesArraySchema);
+        bytesArray.add(ByteBuffer.wrap(new byte[]{0x01}));
+        bytesArray.add(ByteBuffer.wrap(new byte[]{0x02}));
+
+        // when
+        GenericData.Array<Utf8> resultStringArray = deserializeGeneric(stringArraySchema,
+                serializeGenericFast(stringArray));
+
+        GenericData.Array<Integer> resultIntegerArray = deserializeGeneric(intArraySchema,
+                serializeGenericFast(intArray));
+
+        GenericData.Array<Long> resultLongArray = deserializeGeneric(longArraySchema,
+                serializeGenericFast(longArray));
+
+        GenericData.Array<Double> resultDoubleArray = deserializeGeneric(doubleArraySchema,
+                serializeGenericFast(doubleArray));
+
+        GenericData.Array<Float> resultFloatArray = deserializeGeneric(floatArraySchema,
+                serializeGenericFast(floatArray));
+
+        GenericData.Array<ByteBuffer> resultBytesArray = deserializeGeneric(bytesArraySchema,
+                serializeGenericFast(bytesArray));
+
+        // then
+        Assert.assertEquals(2, resultStringArray.size());
+        Assert.assertEquals("aaa", resultStringArray.get(0).toString());
+        Assert.assertEquals("abc", resultStringArray.get(1).toString());
+
+        Assert.assertEquals(2, resultIntegerArray.size());
+        Assert.assertEquals(Integer.valueOf(1), resultIntegerArray.get(0));
+        Assert.assertEquals(Integer.valueOf(2), resultIntegerArray.get(1));
+
+        Assert.assertEquals(2, resultLongArray.size());
+        Assert.assertEquals(Long.valueOf(1L), resultLongArray.get(0));
+        Assert.assertEquals(Long.valueOf(2L), resultLongArray.get(1));
+
+        Assert.assertEquals(2, resultDoubleArray.size());
+        Assert.assertEquals(Double.valueOf(1.0), resultDoubleArray.get(0));
+        Assert.assertEquals(Double.valueOf(2.0), resultDoubleArray.get(1));
+
+        Assert.assertEquals(2, resultFloatArray.size());
+        Assert.assertEquals(Float.valueOf(1f), resultFloatArray.get(0));
+        Assert.assertEquals(Float.valueOf(2f), resultFloatArray.get(1));
+
+        Assert.assertEquals(2, resultBytesArray.size());
+        Assert.assertEquals(0x01, resultBytesArray.get(0).get());
+        Assert.assertEquals(0x02, resultBytesArray.get(1).get());
     }
 
     @Test
@@ -365,6 +461,90 @@ public class FastGenericSerializerGeneratorTest {
         Assert.assertEquals(2, array.size());
         Assert.assertEquals("abc", array.get(0).get("field").toString());
         Assert.assertEquals("abc", array.get(1).get("field").toString());
+    }
+
+    @Test
+    public void shouldWriteMapOfPrimitives() {
+        // given
+        Schema stringMapSchema = Schema.createMap(Schema.create(Schema.Type.STRING));
+
+        Map<String, String> stringMap = new HashMap<>(0);
+        stringMap.put("1", "abc");
+        stringMap.put("2", "aaa");
+
+        Schema intMapSchema = Schema.createMap(Schema.create(Schema.Type.INT));
+
+        Map<String, Integer> intMap = new HashMap<>(0);
+        intMap.put("1", 1);
+        intMap.put("2", 2);
+
+        Schema longMapSchema = Schema.createMap(Schema.create(Schema.Type.LONG));
+
+        Map<String, Long> longMap = new HashMap<>(0);
+        longMap.put("1", 1L);
+        longMap.put("2", 2L);
+
+        Schema doubleMapSchema = Schema.createMap(Schema.create(Schema.Type.DOUBLE));
+
+        Map<String, Double> doubleMap = new HashMap<>(0);
+        doubleMap.put("1", 1.0);
+        doubleMap.put("2", 2.0);
+
+        Schema floatMapSchema = Schema.createMap(Schema.create(Schema.Type.FLOAT));
+
+        Map<String, Float> floatMap = new HashMap<>(0);
+        floatMap.put("1", 1.0f);
+        floatMap.put("2", 2.0f);
+
+        Schema bytesMapSchema = Schema.createMap(Schema.create(Schema.Type.BYTES));
+
+        Map<String, ByteBuffer> bytesMap = new HashMap<>(0);
+        bytesMap.put("1", ByteBuffer.wrap(new byte[]{0x01}));
+        bytesMap.put("2", ByteBuffer.wrap(new byte[]{0x02}));
+
+        // when
+        Map<Utf8, Utf8> resultStringMap = deserializeGeneric(stringMapSchema,
+                serializeGenericFast(stringMap, stringMapSchema));
+
+        Map<Utf8, Integer> resultIntegerMap = deserializeGeneric(intMapSchema,
+                serializeGenericFast(intMap, intMapSchema));
+
+        Map<Utf8, Long> resultLongMap = deserializeGeneric(longMapSchema,
+                serializeGenericFast(longMap, longMapSchema));
+
+        Map<Utf8, Double> resultDoubleMap = deserializeGeneric(doubleMapSchema,
+                serializeGenericFast(doubleMap, doubleMapSchema));
+
+        Map<Utf8, Float> resultFloatMap = deserializeGeneric(floatMapSchema,
+                serializeGenericFast(floatMap, floatMapSchema));
+
+        Map<Utf8, ByteBuffer> resultBytesMap = deserializeGeneric(bytesMapSchema,
+                serializeGenericFast(bytesMap, bytesMapSchema));
+
+        // then
+        Assert.assertEquals(2, resultStringMap.size());
+        Assert.assertEquals("abc", resultStringMap.get(new Utf8("1")).toString());
+        Assert.assertEquals("aaa", resultStringMap.get(new Utf8("2")).toString());
+
+        Assert.assertEquals(2, resultIntegerMap.size());
+        Assert.assertEquals(Integer.valueOf(1), resultIntegerMap.get(new Utf8("1")));
+        Assert.assertEquals(Integer.valueOf(2), resultIntegerMap.get(new Utf8("2")));
+
+        Assert.assertEquals(2, resultLongMap.size());
+        Assert.assertEquals(Long.valueOf(1L), resultLongMap.get(new Utf8("1")));
+        Assert.assertEquals(Long.valueOf(2L), resultLongMap.get(new Utf8("2")));
+
+        Assert.assertEquals(2, resultDoubleMap.size());
+        Assert.assertEquals(Double.valueOf(1.0), resultDoubleMap.get(new Utf8("1")));
+        Assert.assertEquals(Double.valueOf(2.0), resultDoubleMap.get(new Utf8("2")));
+
+        Assert.assertEquals(2, resultFloatMap.size());
+        Assert.assertEquals(Float.valueOf(1f), resultFloatMap.get(new Utf8("1")));
+        Assert.assertEquals(Float.valueOf(2f), resultFloatMap.get(new Utf8("2")));
+
+        Assert.assertEquals(2, resultBytesMap.size());
+        Assert.assertEquals(0x01, resultBytesMap.get(new Utf8("1")).get());
+        Assert.assertEquals(0x02, resultBytesMap.get(new Utf8("2")).get());
     }
 
     @Test

--- a/src/test/java/com/rtbhouse/utils/avro/FastSerdeTestsSupport.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastSerdeTestsSupport.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.BinaryEncoder;
@@ -23,18 +24,20 @@ import org.codehaus.jackson.node.NullNode;
 
 public final class FastSerdeTestsSupport {
 
+    public static final String NAMESPACE = "com.rtbhouse.utils.generated.avro";
+
     private FastSerdeTestsSupport() {
     }
 
     public static Schema createRecord(String name, Schema.Field... fields) {
-        Schema schema = Schema.createRecord(name, name, "com.adpilot.utils.generated.avro", false);
+        Schema schema = Schema.createRecord(name, name, NAMESPACE, false);
         schema.setFields(Arrays.asList(fields));
 
         return schema;
     }
 
     public static Schema.Field createField(String name, Schema schema) {
-        return new Schema.Field(name, schema, "", null, Schema.Field.Order.ASCENDING);
+        return new Schema.Field(name, schema, "", (Object) null, Schema.Field.Order.ASCENDING);
     }
 
     public static Schema.Field createUnionField(String name, Schema... schemas) {
@@ -43,38 +46,38 @@ public final class FastSerdeTestsSupport {
         typeList.addAll(Arrays.asList(schemas));
 
         Schema unionSchema = Schema.createUnion(typeList);
-        return new Schema.Field(name, unionSchema, null, NullNode.getInstance(), Schema.Field.Order.ASCENDING);
+        return new Schema.Field(name, unionSchema, null, Schema.Field.Order.ASCENDING);
     }
 
     public static Schema.Field createPrimitiveFieldSchema(String name, Schema.Type type) {
-        return new Schema.Field(name, Schema.create(type), null, null);
+        return new Schema.Field(name, Schema.create(type), null, (Object) null);
     }
 
     public static Schema.Field createPrimitiveUnionFieldSchema(String name, Schema.Type... types) {
         List<Schema> typeList = new ArrayList<>();
         typeList.add(Schema.create(Schema.Type.NULL));
-        typeList.addAll(Arrays.asList(types).stream().map(Schema::create).collect(Collectors.toList()));
+        typeList.addAll(Arrays.stream(types).map(Schema::create).collect(Collectors.toList()));
 
         Schema unionSchema = Schema.createUnion(typeList);
-        return new Schema.Field(name, unionSchema, null, NullNode.getInstance(), Schema.Field.Order.ASCENDING);
+        return new Schema.Field(name, unionSchema, null, (Object) null, Schema.Field.Order.ASCENDING);
     }
 
     public static Schema.Field createArrayFieldSchema(String name, Schema elementType, String... aliases) {
-        return addAliases(new Schema.Field(name, Schema.createArray(elementType), null, null,
+        return addAliases(new Schema.Field(name, Schema.createArray(elementType), null, (Object) null,
             Schema.Field.Order.ASCENDING), aliases);
     }
 
     public static Schema.Field createMapFieldSchema(String name, Schema valueType, String... aliases) {
-        return addAliases(new Schema.Field(name, Schema.createMap(valueType), null, null,
+        return addAliases(new Schema.Field(name, Schema.createMap(valueType), null, (Object) null,
             Schema.Field.Order.ASCENDING), aliases);
     }
 
     public static Schema createFixedSchema(String name, int size) {
-        return Schema.createFixed(name, "", "com.adpilot.utils.generated.avro", size);
+        return Schema.createFixed(name, "", NAMESPACE, size);
     }
 
     public static Schema createEnumSchema(String name, String[] ordinals) {
-        return Schema.createEnum(name, "", "com.adpilot.utils.generated.avro", Arrays.asList(ordinals));
+        return Schema.createEnum(name, "", NAMESPACE, Arrays.asList(ordinals));
     }
 
     public static Schema createUnionSchema(Schema... schemas) {
@@ -158,11 +161,11 @@ public final class FastSerdeTestsSupport {
 
         record.put("testFixed", new com.rtbhouse.utils.generated.avro.TestFixed(new byte[] { 0x01 }));
         record.put("testFixedArray", Collections.EMPTY_LIST);
-        record.put("testFixedUnionArray", Arrays.asList(new com.rtbhouse.utils.generated.avro.TestFixed(new byte[] { 0x01 })));
+        record.put("testFixedUnionArray", Collections.singletonList(new com.rtbhouse.utils.generated.avro.TestFixed(new byte[] { 0x01 })));
 
         record.put("testEnum", com.rtbhouse.utils.generated.avro.TestEnum.A);
         record.put("testEnumArray", Collections.EMPTY_LIST);
-        record.put("testEnumUnionArray", Arrays.asList(com.rtbhouse.utils.generated.avro.TestEnum.A));
+        record.put("testEnumUnionArray", Collections.singletonList(com.rtbhouse.utils.generated.avro.TestEnum.A));
         record.put("subRecord", new com.rtbhouse.utils.generated.avro.SubRecord());
 
         record.put("recordsArray", Collections.emptyList());
@@ -171,7 +174,7 @@ public final class FastSerdeTestsSupport {
         record.put("recordsMapArray", Collections.emptyMap());
 
         record.put("testInt", 1);
-        record.put("testLong", 1l);
+        record.put("testLong", 1L);
         record.put("testDouble", 1.0);
         record.put("testFloat", 1.0f);
         record.put("testBoolean", true);

--- a/src/test/java/com/rtbhouse/utils/avro/FastSpecificDeserializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastSpecificDeserializerGeneratorTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -497,13 +498,13 @@ public class FastSpecificDeserializerGeneratorTest {
         recordsMap.put("2", testRecord);
 
         // when
-        Map<String, TestRecord> map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
+        Map<Utf8, TestRecord> map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
                 serializeSpecific(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
-        Assert.assertEquals("abc", map.get("1").get("testStringUnion"));
-        Assert.assertEquals("abc", map.get("2").get("testStringUnion"));
+        Assert.assertEquals("abc", map.get(new Utf8("1")).get("testStringUnion").toString());
+        Assert.assertEquals("abc", map.get(new Utf8("2")).get("testStringUnion").toString());
 
         // given
         mapRecordSchema = Schema.createMap(createUnionSchema(TestRecord
@@ -522,15 +523,16 @@ public class FastSpecificDeserializerGeneratorTest {
 
         // then
         Assert.assertEquals(2, map.size());
-        Assert.assertEquals("abc", map.get("1").get("testStringUnion"));
-        Assert.assertEquals("abc", map.get("2").get("testStringUnion"));
+        Assert.assertEquals("abc", map.get(new Utf8("1")).get("testStringUnion"));
+        Assert.assertEquals("abc", map.get(new Utf8("2")).get("testStringUnion"));
     }
 
     @Test
     public void shouldDeserializeNullElementInMap() {
         // given
+        Schema stringSchema = Schema.create(Schema.Type.STRING);
         Schema mapRecordSchema = Schema.createMap(Schema.createUnion(
-                Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
+                stringSchema, Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
 
         Map<String, Object> records = new HashMap<>();
         records.put("0", "0");
@@ -538,14 +540,14 @@ public class FastSpecificDeserializerGeneratorTest {
         records.put("2", 2);
 
         // when
-        Map<String, Object> map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
+        Map<Utf8, Object> map = deserializeSpecificFast(mapRecordSchema, mapRecordSchema,
                 serializeSpecific(records, mapRecordSchema));
 
         // then
         Assert.assertEquals(3, map.size());
-        Assert.assertEquals("0", map.get("0"));
-        Assert.assertNull(map.get("1"));
-        Assert.assertEquals(2, map.get("2"));
+        Assert.assertEquals("0", map.get(new Utf8("0")).toString());
+        Assert.assertNull(map.get(new Utf8("1")));
+        Assert.assertEquals(2, map.get(new Utf8("2")));
     }
 
     @Test
@@ -565,7 +567,7 @@ public class FastSpecificDeserializerGeneratorTest {
 
         // then
         Assert.assertEquals(3, array.size());
-        Assert.assertEquals("0", array.get(0));
+        Assert.assertEquals("0", array.get(0).toString());
         Assert.assertNull(array.get(1));
         Assert.assertEquals(2, array.get(2));
     }

--- a/src/test/java/com/rtbhouse/utils/avro/FastSpecificSerializerGeneratorTest.java
+++ b/src/test/java/com/rtbhouse/utils/avro/FastSpecificSerializerGeneratorTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
@@ -292,6 +293,7 @@ public class FastSpecificSerializerGeneratorTest {
     public void shouldWriteMapOfRecords() {
         // given
         Schema mapRecordSchema = Schema.createMap(TestRecord.getClassSchema());
+        GenericData.setStringType(mapRecordSchema, GenericData.StringType.String);
 
         TestRecord testRecord = emptyTestRecord();
         testRecord.put("testString", "abc");
@@ -301,17 +303,18 @@ public class FastSpecificSerializerGeneratorTest {
         recordsMap.put("2", testRecord);
 
         // when
-        Map<Utf8, TestRecord> map = deserializeSpecific(mapRecordSchema,
+        Map<String, TestRecord> map = deserializeSpecific(mapRecordSchema,
                 serializeSpecificFast(recordsMap, mapRecordSchema));
 
         // then
         Assert.assertEquals(2, map.size());
-        Assert.assertEquals("abc", map.get(new Utf8("1")).get("testString"));
-        Assert.assertEquals("abc", map.get(new Utf8("2")).get("testString"));
+        Assert.assertEquals("abc", map.get("1").get("testString"));
+        Assert.assertEquals("abc", map.get("2").get("testString"));
 
         // given
         mapRecordSchema = Schema.createMap(createUnionSchema(TestRecord
                 .getClassSchema()));
+        GenericData.setStringType(mapRecordSchema, GenericData.StringType.String);
 
         testRecord = emptyTestRecord();
         testRecord.put("testString", "abc");
@@ -325,8 +328,8 @@ public class FastSpecificSerializerGeneratorTest {
 
         // then
         Assert.assertEquals(2, map.size());
-        Assert.assertEquals("abc", map.get(new Utf8("1")).get("testString"));
-        Assert.assertEquals("abc", map.get(new Utf8("2")).get("testString"));
+        Assert.assertEquals("abc", map.get("1").get("testString"));
+        Assert.assertEquals("abc", map.get("2").get("testString"));
     }
 
     @Test
@@ -345,7 +348,7 @@ public class FastSpecificSerializerGeneratorTest {
 
         // then
         Assert.assertEquals(3, map.size());
-        Assert.assertEquals(new Utf8("0"), map.get(new Utf8("0")));
+        Assert.assertEquals("0", map.get(new Utf8("0")).toString());
         Assert.assertNull(map.get(new Utf8("1")));
         Assert.assertEquals(2, map.get(new Utf8("2")));
     }


### PR DESCRIPTION
- string type support now adheres to the native avro implementation
- Utf8 is the default string type as in the native implementation (previously: java.lang.String)
- serializers use java.lang.CharSequence, thus support all types of provided string types
- minor fixes in test classes related to introduced string type support changes